### PR TITLE
fix(leads): Story 4.1 — Corregir tipos y request de crear lead (API v2.4)

### DIFF
--- a/_bmad-output/implementation-artifacts/2-5-encriptacion-en-reposo-api-keys-crm.md
+++ b/_bmad-output/implementation-artifacts/2-5-encriptacion-en-reposo-api-keys-crm.md
@@ -1,0 +1,180 @@
+# Historia 2.5: Encriptación en Reposo de API Keys CRM
+
+Status: ready-for-dev
+
+## Historia
+
+Como administrador,
+quiero que la API key de LeadCars (`clienteToken`) se almacene cifrada en MongoDB,
+para que un acceso no autorizado a la base de datos no exponga las credenciales de la cuenta LeadCars.
+
+## Criterios de Aceptación
+
+1. **Dado** un `EncryptionService` disponible en el contexto `leads` (reutilizando la lógica del `EncryptAdapter` de `auth`)
+   **Cuando** se guarda una configuración CRM con `clienteToken`
+   **Entonces** el valor se almacena cifrado con AES-256-CBC en MongoDB
+   **Y** se descifra transparentemente al leer la configuración para uso interno
+
+2. **Dado** que la variable de entorno `ENCRYPTION_KEY` no está definida (o tiene longitud incorrecta)
+   **Cuando** el módulo `LeadsModule` se inicializa
+   **Entonces** la aplicación lanza un error descriptivo en el arranque (fail-fast)
+   **Y** el mensaje indica claramente el problema (ej. `"ENCRYPTION_KEY debe ser una cadena hex de 64 caracteres (32 bytes)"`)
+
+3. **Dado** cualquier respuesta del endpoint `GET /v1/leads/admin/config` o `GET /v1/leads/admin/config/:id`
+   **Cuando** se serializa la respuesta al cliente
+   **Entonces** el `clienteToken` nunca aparece en texto plano
+   **Y** se muestra un valor enmascarado (ej. `"****cde5"` — últimos 4 caracteres visibles)
+
+4. **Dado** un error en cualquier operación CRM
+   **Cuando** se loguea el error (Logger de NestJS)
+   **Entonces** el `clienteToken` en texto plano no aparece en los logs
+   **Y** la sanitización existente en `LeadcarsApiService.sanitizeForLog()` sigue funcionando correctamente
+
+5. **Dado** una configuración CRM existente con `clienteToken` en texto plano (datos legacy)
+   **Cuando** se actualiza vía `PUT /v1/leads/admin/config/:id`
+   **Entonces** el nuevo valor se guarda cifrado
+   **Y** lecturas posteriores devuelven el valor descifrado correctamente para uso interno
+
+## Tareas / Subtareas
+
+- [ ] Crear `CrmEncryptionService` en `leads/infrastructure/services/` (AC: 1, 2)
+  - [ ] Copiar/adaptar lógica de `EncryptAdapter` (`src/context/auth/api-key/infrastructure/encrypt-adapter.ts`)
+  - [ ] Inyectar `ConfigService`, leer `ENCRYPTION_KEY`
+  - [ ] Implementar `encrypt(plainText: string): string` (síncrono, o async si se prefiere)
+  - [ ] Implementar `decrypt(encrypted: string): string`
+  - [ ] En el constructor, validar que `ENCRYPTION_KEY` existe y tiene 64 chars hex; lanzar error si no
+- [ ] Integrar `CrmEncryptionService` en `MongoCrmCompanyConfigRepositoryImpl` (AC: 1, 5)
+  - [ ] En `save()`: cifrar `config.clienteToken` antes de persistir
+  - [ ] En `update()`: cifrar `config.clienteToken` si se actualiza
+  - [ ] En `findById()`, `findByCompanyAndType()`, `findEnabledByCompanyId()`: descifrar `clienteToken` al construir el objeto de retorno
+- [ ] Actualizar `CrmConfigResponseDto` para enmascarar el token en responses (AC: 3)
+  - [ ] Añadir método `maskToken(token: string): string` que muestre solo los últimos 4 chars
+  - [ ] Asegurar que los mappers/serializers usen `maskToken` en lugar del valor crudo
+- [ ] Registrar `CrmEncryptionService` en `LeadsModule` (AC: 1, 2)
+- [ ] Actualizar `.env.example` y documentación con `ENCRYPTION_KEY` (AC: 2)
+- [ ] Tests unitarios para `CrmEncryptionService` (AC: 1, 2, 3)
+  - [ ] Test: encrypt → decrypt produce el valor original
+  - [ ] Test: fallo en arranque si `ENCRYPTION_KEY` no está definida
+  - [ ] Test: fallo en arranque si `ENCRYPTION_KEY` tiene longitud incorrecta
+  - [ ] Test: `maskToken` oculta correctamente el token
+
+## Notas de Desarrollo
+
+### Patrón de referencia — EncryptAdapter existente
+
+El código de referencia está en `src/context/auth/api-key/infrastructure/encrypt-adapter.ts`. **No mover ni modificar** ese archivo — crear uno nuevo en `leads/infrastructure/services/crm-encryption.service.ts`.
+
+```typescript
+// Algoritmo: AES-256-CBC
+// Formato almacenado: "<iv_hex>:<encrypted_hex>"
+// ENCRYPTION_KEY: string hex de 64 chars (32 bytes)
+
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+
+encrypt(plainText: string): string {
+  const IV_LENGTH = 16;
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv('aes-256-cbc', Buffer.from(KEY, 'hex'), iv);
+  let encrypted = cipher.update(plainText, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  return iv.toString('hex') + ':' + encrypted;
+}
+
+decrypt(encrypted: string): string {
+  const [ivHex, encryptedData] = encrypted.split(':');
+  const iv = Buffer.from(ivHex, 'hex');
+  const decipher = createDecipheriv('aes-256-cbc', Buffer.from(KEY, 'hex'), iv);
+  let decrypted = decipher.update(encryptedData, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}
+```
+
+### Validación fail-fast en constructor
+
+```typescript
+constructor(private readonly configService: ConfigService) {
+  const key = this.configService.get<string>('ENCRYPTION_KEY');
+  if (!key || key.length !== 64) {
+    throw new Error('ENCRYPTION_KEY debe ser una cadena hex de 64 caracteres (32 bytes). Configura la variable de entorno.');
+  }
+}
+```
+
+### Archivos a tocar
+
+| Archivo                                                                             | Acción                                     |
+| ----------------------------------------------------------------------------------- | ------------------------------------------ |
+| `leads/infrastructure/services/crm-encryption.service.ts`                           | Crear nuevo                                |
+| `leads/infrastructure/persistence/impl/mongo-crm-company-config.repository.impl.ts` | Modificar (encrypt/decrypt)                |
+| `leads/application/dtos/crm-config.dto.ts`                                          | Modificar (maskToken en response)          |
+| `leads/leads.module.ts`                                                             | Registrar `CrmEncryptionService`           |
+| `leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts`               | **No tocar** — recibe config ya descifrada |
+
+### Schema de MongoDB — sin cambios de estructura
+
+El schema `CrmCompanyConfigSchema` no necesita cambios de estructura. Solo el valor de `config.clienteToken` cambia de texto plano a formato `"<iv_hex>:<encrypted_hex>"`. Esto es backward compatible al nivel de MongoDB (sigue siendo un string).
+
+### Enmascaramiento de token en DTOs
+
+```typescript
+// En CrmConfigResponseDto o en el mapper:
+maskToken(token: string): string {
+  if (!token || token.length <= 4) return '****';
+  return '****' + token.slice(-4);
+}
+```
+
+**IMPORTANTE**: Los últimos 4 caracteres del `clienteToken` original, no del valor cifrado.
+
+### Notas sobre datos legacy
+
+La primera vez que se lee un `clienteToken` legacy (texto plano), el `decrypt()` fallará porque el formato esperado es `"iv:data"`. Se debe manejar este caso:
+
+```typescript
+tryDecrypt(value: string): string {
+  if (!value.includes(':')) {
+    // Es un valor legacy en texto plano — retornar tal cual
+    // (el próximo update lo cifrará automáticamente)
+    return value;
+  }
+  return this.decrypt(value);
+}
+```
+
+### Estructura del módulo
+
+```
+leads/infrastructure/services/
+├── crm-sync-service.factory.ts   (existente)
+└── crm-encryption.service.ts     (nuevo)
+```
+
+### Variable de entorno
+
+```bash
+# .env.example — añadir:
+# Clave de 32 bytes en hex (64 chars) para cifrado AES-256
+# Generar con: openssl rand -hex 32
+ENCRYPTION_KEY=<generado-con-openssl-rand-hex-32>
+```
+
+### Referencias
+
+- Implementación existente de encrypt: `src/context/auth/api-key/infrastructure/encrypt-adapter.ts`
+- Interface de servicio de encriptación: `src/context/auth/api-key/application/services/api-key-encrypt-private-key.ts`
+- Schema CRM config: `src/context/leads/infrastructure/persistence/schemas/crm-company-config.schema.ts`
+- Repository CRM config: `src/context/leads/infrastructure/persistence/impl/mongo-crm-company-config.repository.impl.ts`
+- DTOs CRM: `src/context/leads/application/dtos/crm-config.dto.ts`
+- AGENTS.md leads: `src/context/leads/AGENTS.md` — sección "Known Limitations"
+- AR-10 en epics.md: `ENCRYPTION_KEY=<32 bytes hex>`
+
+## Registro del Agente Dev
+
+### Modelo Utilizado
+
+claude-sonnet-4.6 (github-copilot/claude-sonnet-4.6)
+
+### Notas de Completación
+
+### Lista de Ficheros

--- a/_bmad-output/implementation-artifacts/3-5-tests-unitarios-sync-lead-y-chat.md
+++ b/_bmad-output/implementation-artifacts/3-5-tests-unitarios-sync-lead-y-chat.md
@@ -1,0 +1,212 @@
+# Historia 3.5: Tests Unitarios para Sync de Lead y Chat a CRM
+
+Status: ready-for-dev
+
+## Historia
+
+Como desarrollador,
+quiero tests unitarios para los command handlers `SyncLeadToCrmCommandHandler` y `SyncChatToCrmCommandHandler` y los event handlers de sincronización,
+para asegurar que la lógica de sincronización es correcta y prevenir regresiones.
+
+## Criterios de Aceptación
+
+1. **Dado** `SyncLeadToCrmCommandHandler`
+   **Cuando** se ejecutan los tests
+   **Entonces** cubren: sync exitoso, sync fallido, lead ya sincronizado, datos de contacto no encontrados, config CRM no encontrada/vacía
+
+2. **Dado** `SyncChatToCrmCommandHandler`
+   **Cuando** se ejecutan los tests
+   **Entonces** cubren: sync exitoso, chat ya sincronizado, lead no sincronizado (sin externalLeadId), config sin syncChatConversations, error al marcar chat sincronizado
+
+3. **Dado** `SyncLeadOnLifecycleChangedEventHandler`
+   **Cuando** se ejecutan los tests
+   **Entonces** cubren: lifecycle → LEAD con trigger configurado, sin config CRM, sin datos de contacto, lifecycle no-LEAD (ignorado), visitante sin tenantId
+
+4. **Dado** `SyncChatOnChatClosedEventHandler`
+   **Cuando** se ejecutan los tests
+   **Entonces** cubren: chat cerrado con config habilitada, config sin syncChatConversations, error al obtener mensajes, chat sin mensajes
+
+5. **Dado** cualquiera de los tests anteriores
+   **Cuando** se ejecuta `npm run test:unit`
+   **Entonces** todos los tests pasan sin errores y sin mocks incompletos
+
+## Tareas / Subtareas
+
+- [ ] Crear `__tests__/sync-lead-to-crm-command.handler.spec.ts` (AC: 1)
+  - [ ] Mock: `ILeadContactDataRepository`, `ICrmSyncRecordRepository`, `ICrmCompanyConfigRepository`, `ICrmSyncServiceFactory`, `EventBus`
+  - [ ] Test: sync exitoso — crea CrmSyncRecord con estado 'synced' y publica `LeadSyncedToCrmEvent`
+  - [ ] Test: sync fallido — CrmSyncRecord con estado 'failed' y publica `LeadSyncFailedEvent`
+  - [ ] Test: lead ya sincronizado — retorna éxito sin llamar al adapter
+  - [ ] Test: contactData no encontrado — retorna `LeadContactDataNotFoundError`
+  - [ ] Test: sin configs CRM habilitadas — retorna `CrmNotConfiguredError`
+- [ ] Crear `__tests__/sync-chat-to-crm-command.handler.spec.ts` (AC: 2)
+  - [ ] Mock: `ICrmSyncRecordRepository`, `ICrmCompanyConfigRepository`, `ICrmSyncServiceFactory`, `EventBus`
+  - [ ] Test: sync exitoso — publica `ChatSyncedToCrmEvent` y marca chat como sincronizado
+  - [ ] Test: chat ya sincronizado — retorna `skipped: true` sin llamar al adapter
+  - [ ] Test: lead no sincronizado (sin externalLeadId) — retorna `skipped: true, skipReason: 'Lead no sincronizado con este CRM'`
+  - [ ] Test: config sin `syncChatConversations` — retorna array vacío sin llamar al adapter
+  - [ ] Test: fallo en `adapter.syncChat()` — retorna error con details
+- [ ] Crear `__tests__/sync-lead-on-lifecycle-changed.event-handler.spec.ts` (AC: 3)
+  - [ ] Mock: `CommandBus`, `VisitorV2Repository`, `ICrmCompanyConfigRepository`, `ILeadContactDataRepository`
+  - [ ] Test: lifecycle → LEAD, con trigger `lifecycle_to_lead` y datos de contacto → ejecuta `SyncLeadToCrmCommand`
+  - [ ] Test: lifecycle → LEAD pero sin config CRM → no ejecuta command
+  - [ ] Test: lifecycle → LEAD pero sin datos de contacto → no ejecuta command
+  - [ ] Test: lifecycle → LEAD, datos de contacto sin email ni teléfono → no ejecuta command
+  - [ ] Test: lifecycle es VISITOR (no-LEAD) → ignora el evento completamente
+  - [ ] Test: visitante sin tenantId → no ejecuta command
+- [ ] Crear `__tests__/sync-chat-on-chat-closed.event-handler.spec.ts` (AC: 4)
+  - [ ] Mock: `CommandBus`, `VisitorV2Repository`, `IChatRepository`, `IMessageRepository`, `ICrmCompanyConfigRepository`
+  - [ ] Test: chat cerrado, config con syncChatConversations, mensajes → ejecuta `SyncChatToCrmCommand`
+  - [ ] Test: config sin syncChatConversations → no ejecuta command
+  - [ ] Test: error al obtener mensajes → no ejecuta command (no propaga error)
+  - [ ] Test: chat sin mensajes → no ejecuta command
+- [ ] Verificar que todos los tests pasan con `npm run test:unit` (AC: 5)
+
+## Notas de Desarrollo
+
+### Patrón de referencia — test existente
+
+Usar `save-lead-contact-data-command.handler.spec.ts` como plantilla:
+
+- `src/context/leads/application/commands/__tests__/save-lead-contact-data-command.handler.spec.ts`
+- Módulo NestJS con `Test.createTestingModule`
+- Mocks: `jest.Mocked<T>`
+- UUIDs reales: `Uuid.random().value` (NUNCA strings fake como `'visitor-id'`)
+- Describe en español, assertions en inglés
+
+### Archivos a crear
+
+```
+src/context/leads/application/commands/__tests__/
+├── save-lead-contact-data-command.handler.spec.ts   (existente, referencia)
+├── sync-lead-to-crm-command.handler.spec.ts         (nuevo)
+└── sync-chat-to-crm-command.handler.spec.ts         (nuevo)
+
+src/context/leads/application/events/__tests__/
+├── sync-lead-on-lifecycle-changed.event-handler.spec.ts  (nuevo)
+└── sync-chat-on-chat-closed.event-handler.spec.ts        (nuevo)
+```
+
+### Mocks necesarios para SyncLeadToCrmCommandHandler
+
+```typescript
+// Interfaces a mockear
+import {
+  ILeadContactDataRepository,
+  LEAD_CONTACT_DATA_REPOSITORY,
+} from '../../../domain/lead-contact-data.repository';
+import {
+  ICrmSyncRecordRepository,
+  CRM_SYNC_RECORD_REPOSITORY,
+} from '../../../domain/crm-sync-record.repository';
+import {
+  ICrmCompanyConfigRepository,
+  CRM_COMPANY_CONFIG_REPOSITORY,
+} from '../../../domain/crm-company-config.repository';
+import {
+  ICrmSyncServiceFactory,
+  CRM_SYNC_SERVICE_FACTORY,
+  ICrmSyncService,
+} from '../../../domain/services/crm-sync.service';
+
+// Estructura del módulo de test
+await Test.createTestingModule({
+  providers: [
+    SyncLeadToCrmCommandHandler,
+    { provide: LEAD_CONTACT_DATA_REPOSITORY, useValue: contactDataRepo },
+    { provide: CRM_SYNC_RECORD_REPOSITORY, useValue: syncRecordRepo },
+    { provide: CRM_COMPANY_CONFIG_REPOSITORY, useValue: configRepo },
+    { provide: CRM_SYNC_SERVICE_FACTORY, useValue: crmFactory },
+    { provide: EventBus, useValue: eventBus },
+  ],
+}).compile();
+```
+
+### Estructura del SyncLeadResult para mocks exitosos
+
+```typescript
+// Cuando adapter.syncLead() tiene éxito:
+mockAdapter.syncLead.mockResolvedValue(
+  ok({
+    externalLeadId: '12345',
+    metadata: { referencia: 'REF-001', estado: 'nuevo' },
+  }),
+);
+```
+
+### Estructura del CrmCompanyConfigPrimitives para mocks
+
+```typescript
+const mockConfig: CrmCompanyConfigPrimitives = {
+  id: Uuid.random().value,
+  companyId,
+  crmType: 'leadcars',
+  enabled: true,
+  syncChatConversations: true,
+  triggerEvents: ['lifecycle_to_lead', 'chat_closed'],
+  config: {
+    clienteToken: 'test-token-12345678901',
+    useSandbox: true,
+    concesionarioId: 1,
+    tipoLeadDefault: 7,
+  },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+```
+
+### Mock de VisitorV2Repository para event handlers
+
+```typescript
+const visitor = {
+  toPrimitives: () => ({ tenantId: companyId, id: visitorId }),
+};
+visitorRepo.findById.mockResolvedValue(ok(visitor));
+```
+
+### Notas de comportamiento a verificar
+
+**SyncLeadToCrmCommandHandler — lead ya sincronizado:**
+
+- `syncRecordRepository.findByVisitorId` devuelve record con `status: 'synced'` y `externalLeadId` definido
+- El handler retorna éxito sin llamar a `crmServiceFactory.getAdapter()` ni `adapter.syncLead()`
+
+**SyncChatToCrmCommandHandler — chat ya sincronizado:**
+
+- `syncRecordRepository.isChatSynced` devuelve `ok(true)`
+- Retorna `{ crmType, success: true, skipped: true, skipReason: 'Chat ya sincronizado' }`
+
+**SyncLeadOnLifecycleChangedEventHandler — lifecycle no-LEAD:**
+
+- `event.attributes.newLifecycle` es `'VISITOR'` o cualquier valor distinto de `'LEAD'`
+- El handler retorna sin ejecutar ninguna consulta adicional
+
+### Comandos para ejecutar tests
+
+```bash
+# Todos los tests de leads
+npm run test:unit -- src/context/leads
+
+# Archivo específico
+npm run test:unit -- src/context/leads/application/commands/__tests__/sync-lead-to-crm-command.handler.spec.ts
+```
+
+### Referencias
+
+- Test de referencia: `src/context/leads/application/commands/__tests__/save-lead-contact-data-command.handler.spec.ts`
+- Handler lead sync: `src/context/leads/application/commands/sync-lead-to-crm-command.handler.ts`
+- Handler chat sync: `src/context/leads/application/commands/sync-chat-to-crm-command.handler.ts`
+- Event handler lifecycle: `src/context/leads/application/events/sync-lead-on-lifecycle-changed.event-handler.ts`
+- Event handler chat closed: `src/context/leads/application/events/sync-chat-on-chat-closed.event-handler.ts`
+- Errores de dominio: `src/context/leads/domain/errors/leads.error.ts`
+- Eventos: `src/context/leads/domain/events/lead-synced.event.ts`
+
+## Registro del Agente Dev
+
+### Modelo Utilizado
+
+claude-sonnet-4.6 (github-copilot/claude-sonnet-4.6)
+
+### Notas de Completación
+
+### Lista de Ficheros

--- a/_bmad-output/implementation-artifacts/4-1-corregir-tipos-y-request-crear-lead.md
+++ b/_bmad-output/implementation-artifacts/4-1-corregir-tipos-y-request-crear-lead.md
@@ -1,6 +1,6 @@
 # Historia 4.1: Corregir Tipos y Request de Crear Lead
 
-Status: review
+Status: done
 
 ## Historia
 
@@ -71,6 +71,17 @@ para que la sincronización de leads no falle por nombres de campos incorrectos 
   - [x] Cambiar el tipo del parámetro `request` para aceptar la nueva estructura (preparar para Story 4.2)
 - [x] Actualizar tests si existen (AC: todos)
   - [x] Verificar que `npm run test:unit -- src/context/leads` pasa sin errores
+
+### Review Findings
+
+- [x] [Review][Decision] tipoLeadDefault cambió de string a number sin migración de datos existentes — Resuelto: coerción runtime con validación explícita de tipo string legacy. [leadcars-crm-sync.adapter.ts:234]
+- [x] [Review][Patch] Object.assign(request, additionalData) permite sobreescritura de campos críticos — Corregido: filtrado de keys protegidas con Set + logger warning. [leadcars-crm-sync.adapter.ts:305]
+- [x] [Review][Patch] tipoLeadDefault permite floats — Corregido: añadido Number.isInteger() a validateConfig(). [leadcars-crm-sync.adapter.ts:225]
+- [x] [Review][Patch] DTO crm-config.dto.ts NO actualizado — Corregido: campanaId→campanaCode (string), tipoLeadDefault→number. [crm-config.dto.ts:102-115]
+- [x] [Review][Patch] concesionarioId=0 pasa validación — Corregido: añadido <= 0 al check. [leadcars-crm-sync.adapter.ts:216]
+- [x] [Review][Patch] Fallback campanaCode no lee campanaId legacy — Corregido: añadido campanaId al fallback chain con conversión a string. [leadcars-crm-sync.adapter.ts:257]
+- [x] [Review][Defer] Sin validación de concesionarioId en URL path [leadcars-api.service.ts:122] — deferred, pre-existing
+- [x] [Review][Defer] email y apellidos requeridos por API v2.4 pero no validados/advertidos — deferred, pre-existing
 
 ## Notas de Desarrollo
 

--- a/_bmad-output/implementation-artifacts/4-1-corregir-tipos-y-request-crear-lead.md
+++ b/_bmad-output/implementation-artifacts/4-1-corregir-tipos-y-request-crear-lead.md
@@ -1,0 +1,291 @@
+# Historia 4.1: Corregir Tipos y Request de Crear Lead
+
+Status: review
+
+## Historia
+
+Como desarrollador,
+quiero que los tipos en `leadcars.types.ts` y el mapeo en `leadcars-crm-sync.adapter.ts` coincidan exactamente con la API real de LeadCars v2.4,
+para que la sincronización de leads no falle por nombres de campos incorrectos o tipos de datos erróneos.
+
+## Criterios de Aceptación
+
+1. **Dado** el tipo `LeadcarsCreateLeadRequest`
+   **Cuando** se construye un request para `POST /leads`
+   **Entonces** los campos enviados son exactamente: `nombre`, `apellidos`, `email`, `telefono`, `movil`, `cp`, `provincia`, `comentario`, `url_origen`, `concesionario` (número), `sede` (número), `tipo_lead` (número), `campana` (string) + campos dinámicos al nivel raíz
+   **Y** no existen campos `origen_lead`, `datos_adicionales`, `observaciones`, `concesionario_id`, `sede_id`, `campana_id`, `dni`, `poblacion`
+
+2. **Dado** `LeadcarsTipoLead` (string enum) y `LeadcarsOrigenLead`
+   **Cuando** se compilan los tipos
+   **Entonces** ambos tipos han sido eliminados del código
+   **Y** `tipo_lead` es un `number` (ID numérico de `GET /tipos`)
+
+3. **Dado** la config de LeadCars con `tipoLeadDefault: 7` (número)
+   **Cuando** se valida la configuración en `validateConfig()`
+   **Entonces** la validación acepta cualquier número positivo como `tipoLeadDefault`
+   **Y** no valida contra un enum de strings
+
+4. **Dado** datos de contacto con campo `poblacion`
+   **Cuando** se construye el request para LeadCars
+   **Entonces** el valor se mapea al campo `provincia` de la API
+
+5. **Dado** la llamada a `listCampanas` con `concesionarioId: 123`
+   **Cuando** se ejecuta la petición HTTP
+   **Entonces** la URL es `/campanas/123` (con el ID como parámetro de ruta)
+
+6. **Dado** datos adicionales de Guiders (visitor_id, company_id)
+   **Cuando** se incluyen en el request
+   **Entonces** se envían como campos dinámicos al nivel raíz: `guiders_visitor_id`, `guiders_company_id`
+   **Y** NO se envían dentro de un objeto `datos_adicionales`
+
+7. **Dado** `LeadcarsConfig`
+   **Cuando** se usa en el adapter
+   **Entonces** `tipoLeadDefault` es `number` (no `string`)
+   **Y** existe `campanaCode?: string` (no `campanaId: number`)
+
+## Tareas / Subtareas
+
+- [x] Actualizar `leadcars.types.ts` — tipos del request (AC: 1, 2, 7)
+  - [x] Modificar `LeadcarsCreateLeadRequest`: renombrar `concesionario_id` → `concesionario`, `sede_id` → `sede`, `campana_id` → `campana: string`, `tipo_lead: LeadcarsTipoLead` → `tipo_lead: number`
+  - [x] Eliminar campos: `origen_lead`, `datos_adicionales`, `observaciones`, `dni`, `poblacion`
+  - [x] Añadir campos: `movil?: string`, `cp?: string`, `provincia?: string`, `comentario?: string`, `url_origen?: string`
+  - [x] Añadir index signature: `[key: string]: unknown` para campos dinámicos al nivel raíz
+  - [x] Eliminar tipo `LeadcarsTipoLead` (string enum)
+  - [x] Eliminar tipo `LeadcarsOrigenLead`
+  - [x] Modificar `LeadcarsConfig`: `tipoLeadDefault: string` → `tipoLeadDefault: number`, `campanaId?: number` → `campanaCode?: string`
+- [x] Actualizar `leadcars-crm-sync.adapter.ts` — buildCreateLeadRequest (AC: 1, 3, 4, 6, 7)
+  - [x] Actualizar imports: eliminar `LeadcarsTipoLead` del import
+  - [x] Actualizar `buildCreateLeadRequest()`: usar nuevos nombres de campos
+  - [x] Mapear `poblacion` → `provincia` (AC: 4)
+  - [x] Mapear `dni` → eliminar (no existe en la API real)
+  - [x] Mapear `additionalData` + `guiders_*` como campos al nivel raíz (AC: 6)
+  - [x] Usar `comentario` en lugar de `observaciones`
+  - [x] Usar `config.campanaCode` (string) en lugar de `config.campanaId` (número)
+  - [x] Actualizar `validateConfig()`: eliminar validación contra string enum (AC: 3)
+  - [x] Actualizar `extractLeadcarsConfig()`: usar nuevos nombres de campos del config
+- [x] Actualizar `leadcars-api.service.ts` — listCampanas (AC: 5)
+  - [x] Añadir parámetro `concesionarioId: number` a `listCampanas()`
+  - [x] Cambiar URL: `/campanas` → `/campanas/${concesionarioId}`
+  - [x] Actualizar todas las llamadas a `listCampanas()` en el codebase (buscar en controllers/admin)
+- [x] Actualizar `LeadcarsApiService.addChatConversation()` — firma compatible con Story 4.2
+  - [x] Cambiar el tipo del parámetro `request` para aceptar la nueva estructura (preparar para Story 4.2)
+- [x] Actualizar tests si existen (AC: todos)
+  - [x] Verificar que `npm run test:unit -- src/context/leads` pasa sin errores
+
+## Notas de Desarrollo
+
+### Estado actual vs. estado objetivo
+
+**`LeadcarsCreateLeadRequest` — ANTES (incorrecto):**
+
+```typescript
+export interface LeadcarsCreateLeadRequest {
+  nombre: string;
+  apellidos?: string;
+  email?: string;
+  telefono?: string;
+  dni?: string; // ❌ No existe en API real
+  poblacion?: string; // ❌ Nombre incorrecto
+  concesionario_id: number; // ❌ Nombre incorrecto
+  sede_id?: number; // ❌ Nombre incorrecto
+  campana_id?: number; // ❌ Tipo y nombre incorrectos
+  tipo_lead: LeadcarsTipoLead; // ❌ Tipo incorrecto (debería ser number)
+  origen_lead: LeadcarsOrigenLead; // ❌ No existe en API
+  observaciones?: string; // ❌ Nombre incorrecto
+  datos_adicionales?: Record<string, unknown>; // ❌ Estructura incorrecta
+}
+```
+
+**`LeadcarsCreateLeadRequest` — DESPUÉS (correcto para API v2.4):**
+
+```typescript
+export interface LeadcarsCreateLeadRequest {
+  nombre: string;
+  apellidos?: string;
+  email?: string;
+  telefono?: string;
+  movil?: string; // ✅ Nuevo campo E.164
+  cp?: string; // ✅ Nuevo campo
+  provincia?: string; // ✅ Renombrado de poblacion
+  comentario?: string; // ✅ Renombrado de observaciones
+  url_origen?: string; // ✅ Nuevo campo
+  concesionario: number; // ✅ Corregido de concesionario_id
+  sede?: number; // ✅ Corregido de sede_id
+  tipo_lead: number; // ✅ Ahora es ID numérico
+  campana?: string; // ✅ Ahora es código de texto
+  [key: string]: unknown; // ✅ Campos dinámicos al nivel raíz
+}
+```
+
+### `LeadcarsConfig` — cambios
+
+```typescript
+// ANTES:
+export interface LeadcarsConfig {
+  clienteToken: string;
+  useSandbox: boolean;
+  concesionarioId: number;
+  sedeId?: number;
+  campanaId?: number; // ❌ Número
+  tipoLeadDefault: string; // ❌ String enum
+}
+
+// DESPUÉS:
+export interface LeadcarsConfig {
+  clienteToken: string;
+  useSandbox: boolean;
+  concesionarioId: number;
+  sedeId?: number;
+  campanaCode?: string; // ✅ Código de texto
+  tipoLeadDefault: number; // ✅ ID numérico
+}
+```
+
+### `buildCreateLeadRequest` — DESPUÉS
+
+```typescript
+private buildCreateLeadRequest(
+  contactData: LeadContactDataPrimitives,
+  config: LeadcarsConfig,
+): LeadcarsCreateLeadRequest {
+  const request: LeadcarsCreateLeadRequest = {
+    nombre: contactData.nombre || 'Visitante',
+    concesionario: config.concesionarioId,  // ✅ Nuevo nombre
+    tipo_lead: config.tipoLeadDefault,       // ✅ Ya es número
+    comentario: `Lead generado automáticamente desde chat de Guiders (visitor: ${contactData.visitorId})`,
+  };
+
+  if (contactData.apellidos) request.apellidos = contactData.apellidos;
+  if (contactData.email) request.email = contactData.email;
+  if (contactData.telefono) request.telefono = contactData.telefono;
+  if (contactData.poblacion) request.provincia = contactData.poblacion; // ✅ Mapeado
+  if (config.sedeId) request.sede = config.sedeId;  // ✅ Nuevo nombre
+  if (config.campanaCode) request.campana = config.campanaCode;  // ✅ Código texto
+
+  // Campos dinámicos al nivel raíz (no dentro de datos_adicionales)
+  request['guiders_visitor_id'] = contactData.visitorId;  // ✅
+  request['guiders_company_id'] = contactData.companyId;  // ✅
+  if (contactData.additionalData) {
+    Object.assign(request, contactData.additionalData);   // ✅
+  }
+
+  return request;
+}
+```
+
+### `validateConfig` — DESPUÉS
+
+```typescript
+validateConfig(config: CrmCompanyConfigPrimitives): string[] {
+  const errors: string[] = [];
+  const leadcarsConfig = config.config as Partial<LeadcarsConfig>;
+
+  if (!leadcarsConfig.clienteToken) errors.push('clienteToken es obligatorio');
+  if (typeof leadcarsConfig.concesionarioId !== 'number') errors.push('concesionarioId es obligatorio y debe ser un número');
+  if (leadcarsConfig.useSandbox === undefined) errors.push('useSandbox es obligatorio');
+  if (typeof leadcarsConfig.tipoLeadDefault !== 'number' || leadcarsConfig.tipoLeadDefault <= 0) {
+    errors.push('tipoLeadDefault es obligatorio y debe ser un número positivo (ID de GET /tipos)');
+  }
+  // ✅ Eliminada validación contra string enum
+
+  return errors;
+}
+```
+
+### `listCampanas` — DESPUÉS
+
+```typescript
+async listCampanas(
+  concesionarioId: number,  // ✅ Nuevo parámetro requerido
+  config: LeadcarsConfig,
+): Promise<Result<LeadcarsListCampanasResponse, DomainError>> {
+  const url = `${this.getBaseUrl(config)}/campanas/${concesionarioId}`; // ✅
+  // ...
+}
+```
+
+### Archivos a tocar
+
+| Archivo                                                               | Acción                                                                    |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `leads/infrastructure/adapters/leadcars/leadcars.types.ts`            | Modificar (tipos del request, LeadcarsConfig)                             |
+| `leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts` | Modificar (buildCreateLeadRequest, validateConfig, extractLeadcarsConfig) |
+| `leads/infrastructure/adapters/leadcars/leadcars-api.service.ts`      | Modificar (listCampanas + parámetro)                                      |
+| `leads/infrastructure/controllers/leads-admin.controller.ts`          | Verificar y actualizar llamada a listCampanas                             |
+
+### Búsqueda de llamadas a listCampanas
+
+Antes de modificar la firma, buscar todas las invocaciones:
+
+```bash
+grep -r "listCampanas" src/
+```
+
+Actualizar las llamadas en el controller admin que proxea campañas: el endpoint ya recibe `:concesionarioId` como parámetro de ruta.
+
+### Impacto en CrmCompanyConfigSchema
+
+El schema de MongoDB almacena `config` como objeto genérico `Record<string, unknown>`. Los cambios de nombre de campos en `LeadcarsConfig` **SÍ rompen datos existentes** en la base de datos si existen configs guardadas con `campanaId` (número). Estrategia: el `extractLeadcarsConfig()` debe ser tolerante y leer ambas versiones:
+
+```typescript
+private extractLeadcarsConfig(config: CrmCompanyConfigPrimitives): LeadcarsConfig {
+  const rawConfig = config.config;
+  return {
+    clienteToken: rawConfig.clienteToken as string,
+    useSandbox: rawConfig.useSandbox as boolean,
+    concesionarioId: rawConfig.concesionarioId as number,
+    sedeId: rawConfig.sedeId as number | undefined,
+    campanaCode: (rawConfig.campanaCode || rawConfig.campana) as string | undefined, // compatibilidad
+    tipoLeadDefault: rawConfig.tipoLeadDefault as number,
+  };
+}
+```
+
+### Orden recomendado de implementación
+
+1. Primero actualizar `leadcars.types.ts` (tipos)
+2. Luego `leadcars-crm-sync.adapter.ts` (lógica de mapeo)
+3. Luego `leadcars-api.service.ts` (firma de listCampanas)
+4. Finalmente el controller (pasar concesionarioId)
+
+### Referencias
+
+- Fuente de verdad: `docs/leadcar/LeadCars_API_V2_4.pdf`
+- AGENTS.md leads — tabla de discrepancias: `src/context/leads/AGENTS.md`
+- Tipos actuales: `src/context/leads/infrastructure/adapters/leadcars/leadcars.types.ts`
+- Adapter actual: `src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts`
+- API service actual: `src/context/leads/infrastructure/adapters/leadcars/leadcars-api.service.ts`
+- Controller admin: `src/context/leads/infrastructure/controllers/leads-admin.controller.ts`
+- Story 4.3 (teléfonos E.164) debe implementarse DESPUÉS de esta story
+
+## Registro del Agente Dev
+
+### Modelo Utilizado
+
+claude-sonnet-4.6 (github-copilot/claude-sonnet-4.6)
+
+### Notas de Completación
+
+Implementación completada el 01/04/2026. Cambios realizados:
+
+1. **`leadcars.types.ts`**: Eliminados `LeadcarsTipoLead` y `LeadcarsOrigenLead`. `LeadcarsConfig` actualizado: `campanaId: number` → `campanaCode?: string`, `tipoLeadDefault: string` → `tipoLeadDefault: number`. `LeadcarsCreateLeadRequest` reescrito según API v2.4: `concesionario_id` → `concesionario`, `sede_id` → `sede`, `campana_id` → `campana: string`, `tipo_lead` ahora es `number`; eliminados `origen_lead`, `datos_adicionales`, `observaciones`, `dni`, `poblacion`; añadidos `movil`, `cp`, `provincia`, `comentario`, `url_origen` y el index signature `[key: string]: unknown`.
+
+2. **`leadcars-crm-sync.adapter.ts`**: Import de `LeadcarsTipoLead` eliminado. `buildCreateLeadRequest()` usa los nuevos nombres de campo, mapea `poblacion` → `provincia`, envía datos adicionales (`guiders_visitor_id`, `guiders_company_id`, `additionalData`) al nivel raíz en vez de dentro de `datos_adicionales`. `validateConfig()` ahora valida `tipoLeadDefault` como número positivo. `extractLeadcarsConfig()` lee `campanaCode` o `campana` por compatibilidad con datos existentes en BD.
+
+3. **`leadcars-api.service.ts`**: `listCampanas()` ahora recibe `concesionarioId: number` como primer parámetro y construye la URL `/campanas/${concesionarioId}`.
+
+4. **`leads-admin.controller.ts`**: `getLeadcarsConfigForCompany()` actualizado para usar `campanaCode` (con compatibilidad `campana`) y `tipoLeadDefault: number`. Llamada a `listCampanas()` actualizada para pasar `concesionarioIdNum` como primer argumento.
+
+**Validaciones:**
+
+- 0 errores TypeScript en todo el proyecto
+- 0 errores ESLint en archivos modificados
+- 6/6 tests unitarios del contexto leads pasan
+- 1479/1497 tests totales pasan (sin regresiones)
+
+### Lista de Ficheros
+
+- `src/context/leads/infrastructure/adapters/leadcars/leadcars.types.ts` (modificado)
+- `src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts` (modificado)
+- `src/context/leads/infrastructure/adapters/leadcars/leadcars-api.service.ts` (modificado)
+- `src/context/leads/infrastructure/controllers/leads-admin.controller.ts` (modificado)

--- a/_bmad-output/implementation-artifacts/4-2-alinear-estructura-chat-conversation-api-v24.md
+++ b/_bmad-output/implementation-artifacts/4-2-alinear-estructura-chat-conversation-api-v24.md
@@ -1,0 +1,294 @@
+# Historia 4.2: Alinear Estructura de Chat Conversation con API v2.4
+
+Status: ready-for-dev
+
+## Historia
+
+Como desarrollador,
+quiero que el formato de la conversación de chat enviada a LeadCars use la estructura oficial de la API v2.4,
+para que las conversaciones se registren correctamente en el CRM.
+
+## Criterios de Aceptación
+
+1. **Dado** el tipo `LeadcarsAddChatConversationRequest`
+   **Cuando** se envía a `POST /leads/{idLead}/chat_conversation`
+   **Entonces** el payload tiene la estructura oficial:
+
+   ```json
+   {
+     "chat": {
+       "chat_id": "string",
+       "users": [
+         {
+           "_id": "string",
+           "user": {
+             "name": "string",
+             "first_lastname": "string",
+             "second_lastname": "string",
+             "email": "string",
+             "phone": "string",
+             "id": "string"
+           }
+         },
+         {
+           "_id": "string",
+           "visitor": {
+             "name": "string",
+             "first_lastname": "string",
+             "second_lastname": "string",
+             "email": "string",
+             "phone": "string",
+             "id": "string"
+           }
+         }
+       ],
+       "messages": [
+         {
+           "_id": "string",
+           "message": { "text": "string", "type": "text" },
+           "created_at": "ISO 8601",
+           "user_sender": "string",
+           "interaction_type": "welcome | default | close"
+         }
+       ]
+     }
+   }
+   ```
+
+   **Y** no existen campos `lead_id`, `conversacion`, `fecha_inicio`, `fecha_fin`, `resumen`, `metadata`
+
+2. **Dado** el primer mensaje de la conversación
+   **Cuando** se mapea al formato LeadCars
+   **Entonces** el `interaction_type` es `"welcome"`
+
+3. **Dado** el último mensaje de la conversación
+   **Cuando** se mapea al formato LeadCars
+   **Entonces** el `interaction_type` es `"close"`
+
+4. **Dado** mensajes intermedios (ni primero ni último)
+   **Cuando** se mapean al formato LeadCars
+   **Entonces** el `interaction_type` es `"default"`
+
+5. **Dado** mensajes enviados por el comercial (senderType `'commercial'`)
+   **Cuando** se construye el array `users[]`
+   **Entonces** el usuario comercial aparece con clave `user` (no `visitor`)
+
+6. **Dado** mensajes enviados por el visitante (senderType `'visitor'`)
+   **Cuando** se construye el array `users[]`
+   **Entonces** el visitante aparece con clave `visitor`
+
+7. **Dado** mensajes enviados por bot o sistema (senderType `'bot'` o `'system'`)
+   **Cuando** se mapean
+   **Entonces** se tratan como si fueran del comercial (`user`) en el array de usuarios
+
+## Tareas / Subtareas
+
+- [ ] Actualizar tipos en `leadcars.types.ts` (AC: 1)
+  - [ ] Crear `LeadcarsChatUser` con campos `_id: string` + `user?: LeadcarsUserProfile` + `visitor?: LeadcarsUserProfile`
+  - [ ] Crear `LeadcarsUserProfile` con campos `name`, `first_lastname`, `second_lastname`, `email`, `phone`, `id`
+  - [ ] Crear `LeadcarsChatMessage` con campos `_id`, `message: { text: string; type: 'text' }`, `created_at`, `user_sender`, `interaction_type: 'welcome' | 'default' | 'close'`
+  - [ ] Crear `LeadcarsChatPayload` con campos `chat_id: string`, `users: LeadcarsChatUser[]`, `messages: LeadcarsChatMessage[]`
+  - [ ] Redefinir `LeadcarsAddChatConversationRequest` como `{ chat: LeadcarsChatPayload }`
+  - [ ] Eliminar tipos: `LeadcarsChatMessage` (versión antigua con `emisor`/`mensaje`/`fecha`), campos `conversacion`, `fecha_inicio`, `fecha_fin`, `resumen`, `metadata` del request
+  - [ ] Actualizar `LeadcarsAddConversationResponse` si es necesario
+- [ ] Actualizar `leadcars-crm-sync.adapter.ts` — syncChat (AC: 1-7)
+  - [ ] Reescribir `convertMessagesToLeadcarsFormat()` para generar la estructura `{ chat: { chat_id, users[], messages[] } }`
+  - [ ] Implementar `buildChatUsers()`: deduplica emisores y los convierte en `LeadcarsChatUser[]`
+  - [ ] Implementar asignación de `interaction_type`: primer mensaje → `'welcome'`, último → `'close'`, resto → `'default'`
+  - [ ] Implementar `buildUserProfile()` con datos disponibles (puede ser parcial si no hay datos completos)
+  - [ ] Actualizar `syncChat()` para usar la nueva estructura sin `lead_id` (el ID va en la URL, ya está bien)
+- [ ] Actualizar `leadcars-api.service.ts` — addChatConversation (AC: 1)
+  - [ ] Simplificar el método: el `lead_id` ya no va en el body (solo en la URL)
+  - [ ] Actualizar tipo del parámetro `request` a `LeadcarsAddChatConversationRequest` (sin el `Omit<..., 'lead_id'>`)
+  - [ ] Eliminar el spread `{ ...request, lead_id: leadId }` — enviar directamente el `{ chat: ... }`
+- [ ] Verificar que los tests existentes pasan con `npm run test:unit -- src/context/leads`
+
+## Notas de Desarrollo
+
+### Estructura de tipos nueva completa
+
+```typescript
+// Perfil de usuario en el chat
+export interface LeadcarsUserProfile {
+  name?: string;
+  first_lastname?: string;
+  second_lastname?: string;
+  email?: string;
+  phone?: string;
+  id: string;
+}
+
+// Participante del chat (user = comercial, visitor = visitante)
+export interface LeadcarsChatUser {
+  _id: string;
+  user?: LeadcarsUserProfile; // Comercial o bot
+  visitor?: LeadcarsUserProfile; // Visitante
+}
+
+// Mensaje individual
+export interface LeadcarsChatMessage {
+  _id: string;
+  message: {
+    text: string;
+    type: 'text';
+  };
+  created_at: string; // ISO 8601
+  user_sender: string; // _id del usuario en users[]
+  interaction_type: 'welcome' | 'default' | 'close';
+}
+
+// Cuerpo del chat completo
+export interface LeadcarsChatPayload {
+  chat_id: string;
+  users: LeadcarsChatUser[];
+  messages: LeadcarsChatMessage[];
+}
+
+// Request completo para POST /leads/{idLead}/chat_conversation
+export interface LeadcarsAddChatConversationRequest {
+  chat: LeadcarsChatPayload;
+}
+```
+
+### Lógica de `convertMessagesToLeadcarsFormat`
+
+```typescript
+private convertMessagesToLeadcarsFormat(
+  chatData: ChatSyncData,
+): LeadcarsAddChatConversationRequest {
+  const { chatId, visitorId, messages } = chatData;
+
+  // 1. Construir mapa de participantes únicos
+  const usersMap = new Map<string, LeadcarsChatUser>();
+
+  for (const msg of messages) {
+    const senderId = msg.metadata?.messageId as string || msg.sentAt.toISOString();
+    const userKey = msg.senderType === 'visitor' ? visitorId : 'commercial';
+
+    if (!usersMap.has(userKey)) {
+      const chatUser: LeadcarsChatUser = { _id: userKey };
+      if (msg.senderType === 'visitor') {
+        chatUser.visitor = { id: visitorId };
+      } else {
+        chatUser.user = { id: 'commercial' };
+      }
+      usersMap.set(userKey, chatUser);
+    }
+  }
+
+  // 2. Construir mensajes con interaction_type
+  const totalMessages = messages.length;
+  const chatMessages: LeadcarsChatMessage[] = messages.map((msg, index) => {
+    let interaction_type: 'welcome' | 'default' | 'close';
+    if (index === 0) interaction_type = 'welcome';
+    else if (index === totalMessages - 1) interaction_type = 'close';
+    else interaction_type = 'default';
+
+    const userKey = msg.senderType === 'visitor' ? visitorId : 'commercial';
+
+    return {
+      _id: `${chatId}-msg-${index}`,
+      message: { text: msg.content, type: 'text' },
+      created_at: msg.sentAt.toISOString(),
+      user_sender: userKey,
+      interaction_type,
+    };
+  });
+
+  return {
+    chat: {
+      chat_id: chatId,
+      users: Array.from(usersMap.values()),
+      messages: chatMessages,
+    },
+  };
+}
+```
+
+### Actualización de `addChatConversation` en ApiService
+
+```typescript
+// ANTES:
+async addChatConversation(
+  leadId: number,
+  request: Omit<LeadcarsAddChatConversationRequest, 'lead_id'>,
+  config: LeadcarsConfig,
+): Promise<Result<LeadcarsAddConversationResponse, DomainError>> {
+  const url = `${this.getBaseUrl(config)}/leads/${leadId}/chat_conversation`;
+  const payload: LeadcarsAddChatConversationRequest = {
+    ...request,
+    lead_id: leadId,  // ❌ lead_id no va en el body
+  };
+  // ...
+}
+
+// DESPUÉS:
+async addChatConversation(
+  leadId: number,
+  request: LeadcarsAddChatConversationRequest,  // ✅ sin Omit
+  config: LeadcarsConfig,
+): Promise<Result<LeadcarsAddConversationResponse, DomainError>> {
+  const url = `${this.getBaseUrl(config)}/leads/${leadId}/chat_conversation`;
+  // Enviar directamente el request (sin añadir lead_id al body)
+  return this.executeWithRetry<LeadcarsAddConversationResponse>(
+    () => this.post<LeadcarsAddConversationResponse>(url, request, config),
+    'addChatConversation',
+  );
+}
+```
+
+### Actualización del adapter — syncChat
+
+```typescript
+// ANTES en syncChat:
+const conversacion = this.convertMessagesToLeadcarsFormat(chatData.messages);
+const result = await this.apiService.addChatConversation(
+  leadId,
+  {
+    conversacion,           // ❌ formato incorrecto
+    fecha_inicio: ...,      // ❌ no existe en API real
+    fecha_fin: ...,         // ❌ no existe
+    resumen: ...,           // ❌ no existe
+    metadata: ...,          // ❌ no existe
+  },
+  leadcarsConfig,
+);
+
+// DESPUÉS:
+const chatRequest = this.convertMessagesToLeadcarsFormat(chatData);  // ✅ retorna { chat: {...} }
+const result = await this.apiService.addChatConversation(
+  leadId,
+  chatRequest,             // ✅ formato correcto
+  leadcarsConfig,
+);
+```
+
+### Dependencia con Story 4.1
+
+Esta historia **depende de Story 4.1**. El tipo `LeadcarsChatMessage` existente colisiona con el nuevo. Asegurarse de que Story 4.1 ya eliminó el antiguo tipo antes de implementar esta historia. Si se implementan en paralelo, coordinar los cambios en `leadcars.types.ts`.
+
+### Archivos a tocar
+
+| Archivo                                                               | Acción                                                |
+| --------------------------------------------------------------------- | ----------------------------------------------------- |
+| `leads/infrastructure/adapters/leadcars/leadcars.types.ts`            | Modificar (nuevos tipos de chat)                      |
+| `leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts` | Modificar (convertMessagesToLeadcarsFormat, syncChat) |
+| `leads/infrastructure/adapters/leadcars/leadcars-api.service.ts`      | Modificar (addChatConversation sin lead_id en body)   |
+
+### Referencias
+
+- Estructura oficial: `src/context/leads/AGENTS.md` sección "Estructura de Chat Conversation"
+- Fuente de verdad: `docs/leadcar/LeadCars_API_V2_4.pdf`
+- Adapter actual: `src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts` líneas 100-179
+- Tipos actuales: `src/context/leads/infrastructure/adapters/leadcars/leadcars.types.ts` líneas 85-118
+- Dependencia: Story 4.1 debe completarse primero
+
+## Registro del Agente Dev
+
+### Modelo Utilizado
+
+claude-sonnet-4.6 (github-copilot/claude-sonnet-4.6)
+
+### Notas de Completación
+
+### Lista de Ficheros

--- a/_bmad-output/implementation-artifacts/4-3-validacion-formato-e164-telefonos.md
+++ b/_bmad-output/implementation-artifacts/4-3-validacion-formato-e164-telefonos.md
@@ -1,0 +1,165 @@
+# Historia 4.3: Validación de Formato E.164 para Teléfonos
+
+Status: ready-for-dev
+
+## Historia
+
+Como desarrollador,
+quiero que los teléfonos se validen y normalicen a formato E.164 antes de enviarlos a LeadCars,
+para cumplir con el formato obligatorio de la API v2.4 (`+CODIGOPAIS + NUMERO`, ej: `+34612345678`).
+
+## Criterios de Aceptación
+
+1. **Dado** un teléfono `612345678` (sin prefijo de país)
+   **Cuando** se construye el request para LeadCars
+   **Entonces** se envía como `+34612345678` (España como país por defecto, configurable)
+
+2. **Dado** un teléfono `+34612345678` (ya en formato E.164)
+   **Cuando** se construye el request
+   **Entonces** se envía tal cual sin modificación
+
+3. **Dado** un teléfono con formato no E.164 (ej: `612 34 56 78`, `612-345-678`, `(612) 345-678`)
+   **Cuando** se construye el request
+   **Entonces** se elimina todo lo que no sean dígitos, se antepone `+34` y se envía como `+34612345678`
+
+4. **Dado** datos de contacto con `telefono` presente pero sin `movil`
+   **Cuando** se envía a LeadCars
+   **Entonces** solo se incluye el campo `telefono` (normalizado)
+   **Y** el campo `movil` NO aparece en el request
+
+5. **Dado** datos de contacto con `telefono` y `movil` ambos presentes
+   **Cuando** se construye el request
+   **Entonces** ambos se incluyen normalizados a E.164
+
+6. **Dado** un teléfono vacío o `null`
+   **Cuando** se intenta normalizar
+   **Entonces** se omite el campo del request (no se envía)
+
+7. **Dado** el código de país configurado en `LeadcarsConfig` (campo `defaultCountryCode?: string`)
+   **Cuando** se normaliza un teléfono sin prefijo
+   **Entonces** se usa el código configurado (ej. `'ES'` → `+34`, `'PT'` → `+351`)
+   **Y** si no está configurado, se asume `'ES'` como default
+
+## Tareas / Subtareas
+
+- [ ] Crear `PhoneNormalizationService` o función utilitaria en el adapter (AC: 1-7)
+  - [ ] Implementar `normalizeToE164(phone: string, defaultCountryCode?: string): string | null`
+  - [ ] Si el teléfono ya empieza con `+`, retornarlo tal cual (ya es E.164)
+  - [ ] Si no tiene `+`, eliminar todos los caracteres no numéricos y añadir el prefijo del país
+  - [ ] Mapeo de código de país: `{ ES: '+34', PT: '+351', FR: '+33', DE: '+49', IT: '+39', GB: '+44' }` (extensible)
+  - [ ] Si el teléfono resultante queda vacío o tiene menos de 7 dígitos, retornar `null`
+- [ ] Añadir campo `defaultCountryCode?: string` a `LeadcarsConfig` (AC: 7)
+- [ ] Integrar normalización en `buildCreateLeadRequest()` del adapter (AC: 1-6)
+  - [ ] Normalizar `contactData.telefono` antes de asignarlo a `request.telefono`
+  - [ ] Normalizar campo `movil` si existe (de `contactData.additionalData?.movil`)
+  - [ ] Omitir el campo si `normalizeToE164` retorna `null`
+- [ ] Escribir tests unitarios para `normalizeToE164` (AC: 1-7)
+  - [ ] Test: teléfono español sin prefijo → `+34XXXXXXXXX`
+  - [ ] Test: teléfono ya en E.164 → sin cambios
+  - [ ] Test: teléfono con espacios/guiones → normalizado correctamente
+  - [ ] Test: teléfono vacío → `null`
+  - [ ] Test: teléfono con código de país diferente al default
+
+## Notas de Desarrollo
+
+### Función de normalización
+
+```typescript
+// En leadcars-crm-sync.adapter.ts (puede ser método privado)
+
+private readonly COUNTRY_PREFIXES: Record<string, string> = {
+  ES: '+34',
+  PT: '+351',
+  FR: '+33',
+  DE: '+49',
+  IT: '+39',
+  GB: '+44',
+  MX: '+52',
+  AR: '+54',
+  CO: '+57',
+  CL: '+56',
+};
+
+private normalizeToE164(
+  phone: string | undefined,
+  countryCode: string = 'ES',
+): string | null {
+  if (!phone) return null;
+
+  const trimmed = phone.trim();
+  if (!trimmed) return null;
+
+  // Ya está en E.164
+  if (trimmed.startsWith('+')) {
+    const digitsOnly = trimmed.replace(/\D/g, '');
+    return digitsOnly.length >= 7 ? trimmed.replace(/[\s\-()]/g, '') : null;
+  }
+
+  // Eliminar todo excepto dígitos
+  const digits = trimmed.replace(/\D/g, '');
+  if (digits.length < 7) return null;
+
+  const prefix = this.COUNTRY_PREFIXES[countryCode.toUpperCase()] ?? '+34';
+  return `${prefix}${digits}`;
+}
+```
+
+### Integración en `buildCreateLeadRequest`
+
+```typescript
+// En buildCreateLeadRequest() — después de Story 4.1:
+const defaultCountryCode = (config as any).defaultCountryCode || 'ES';
+
+const normalizedTelefono = this.normalizeToE164(
+  contactData.telefono,
+  defaultCountryCode,
+);
+if (normalizedTelefono) request.telefono = normalizedTelefono;
+
+// movil desde additionalData (si existe)
+const rawMovil = contactData.additionalData?.movil as string | undefined;
+const normalizedMovil = this.normalizeToE164(rawMovil, defaultCountryCode);
+if (normalizedMovil) request.movil = normalizedMovil;
+```
+
+### Añadir `defaultCountryCode` a `LeadcarsConfig`
+
+```typescript
+export interface LeadcarsConfig {
+  clienteToken: string;
+  useSandbox: boolean;
+  concesionarioId: number;
+  sedeId?: number;
+  campanaCode?: string;
+  tipoLeadDefault: number;
+  defaultCountryCode?: string; // ✅ Nuevo: 'ES' por defecto
+}
+```
+
+### Dependencia con Story 4.1
+
+Esta historia **depende de Story 4.1** (debe completarse primero). Los campos `telefono` y `movil` en el request ya deben tener los nombres correctos según Story 4.1.
+
+### Archivos a tocar
+
+| Archivo                                                               | Acción                                                         |
+| --------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `leads/infrastructure/adapters/leadcars/leadcars.types.ts`            | Añadir `defaultCountryCode` a `LeadcarsConfig`                 |
+| `leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts` | Añadir `normalizeToE164`, integrar en `buildCreateLeadRequest` |
+
+### Referencias
+
+- Documentación E.164: formato `+[código país][número]`, sin espacios ni guiones
+- AGENTS.md leads — tabla de discrepancias, fila "Teléfono": `src/context/leads/AGENTS.md`
+- `buildCreateLeadRequest` actual: `src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts` líneas 260-318
+- FR-19 en epics.md: teléfonos en E.164 obligatorio
+
+## Registro del Agente Dev
+
+### Modelo Utilizado
+
+claude-sonnet-4.6 (github-copilot/claude-sonnet-4.6)
+
+### Notas de Completación
+
+### Lista de Ficheros

--- a/_bmad-output/implementation-artifacts/4-4-actualizar-tipos-response-y-comentarios.md
+++ b/_bmad-output/implementation-artifacts/4-4-actualizar-tipos-response-y-comentarios.md
@@ -1,0 +1,221 @@
+# Historia 4.4: Actualizar Tipos de Response y Comentarios
+
+Status: ready-for-dev
+
+## Historia
+
+Como desarrollador,
+quiero que los tipos de response de LeadCars y el request de comentarios coincidan con la API real v2.4,
+para que el manejo de respuestas sea correcto y no se envíen campos inexistentes.
+
+## Criterios de Aceptación
+
+1. **Dado** el tipo `LeadcarsAddCommentRequest`
+   **Cuando** se usa para registrar un comentario en `POST /leads/{idLead}/comments`
+   **Entonces** solo contiene el campo `comentario: string`
+   **Y** no contiene `tipo`, `privado`, ni `lead_id` (el lead_id va en la URL)
+
+2. **Dado** la llamada a `apiService.addComment(leadId, { comentario: 'texto' }, config)`
+   **Cuando** se ejecuta
+   **Entonces** el body enviado a LeadCars es exactamente `{ "comentario": "texto" }`
+   **Y** el `leadId` se usa solo en la URL `/leads/{leadId}/comments`
+
+3. **Dado** el tipo `LeadcarsCreateLeadResponse`
+   **Cuando** se define
+   **Entonces** refleja que la respuesta real de la API es opaca (puede ser cualquier objeto con `success: boolean`)
+   **Y** los campos `data.referencia`, `data.estado`, `data.created_at`, `data.updated_at` se marcan como opcionales
+
+4. **Dado** el tipo `LeadcarsAddCommentResponse`
+   **Cuando** se define
+   **Entonces** refleja que la respuesta puede ser cualquier objeto con `success: boolean`
+   **Y** los campos en `data` se marcan como opcionales o se simplifica a `data?: Record<string, unknown>`
+
+5. **Dado** las responses de discovery (`LeadcarsListConcesionariosResponse`, `LeadcarsListSedesResponse`, `LeadcarsListCampanasResponse`, `LeadcarsListTiposResponse`)
+   **Cuando** se definen
+   **Entonces** el wrapper de respuesta es consistente: `{ data: T[] }` (sin campo `success` ni `error` si la API real no los usa)
+
+6. **Dado** el tipo `LeadcarsErrorResponse`
+   **Cuando** se evalúa si es necesario
+   **Entonces** se mantiene o elimina según si la API real devuelve ese formato exacto
+
+## Tareas / Subtareas
+
+- [ ] Simplificar `LeadcarsAddCommentRequest` en `leadcars.types.ts` (AC: 1)
+  - [ ] Dejar solo `{ comentario: string }` — eliminar `tipo`, `privado`, `lead_id`
+- [ ] Actualizar `addComment()` en `leadcars-api.service.ts` (AC: 2)
+  - [ ] Cambiar firma: `request: { comentario: string }` en lugar de `Omit<LeadcarsAddCommentRequest, 'lead_id'>`
+  - [ ] El body enviado debe ser solo `{ comentario: texto }` sin construir un objeto con `lead_id`
+  - [ ] Eliminar el spread `{ ...request, lead_id: leadId }` — enviar `{ comentario: request.comentario }` directamente
+- [ ] Actualizar `LeadcarsCreateLeadResponse` (AC: 3)
+  - [ ] Marcar todos los campos de `data` como opcionales: `id?: number`, `referencia?: string`, `estado?: string`, `created_at?: string`, `updated_at?: string`
+  - [ ] Mantener `success: boolean` como campo principal
+- [ ] Actualizar `LeadcarsAddCommentResponse` (AC: 4)
+  - [ ] Simplificar `data` a `data?: Record<string, unknown>` o mantener campos como opcionales
+- [ ] Revisar y ajustar `LeadcarsAddConversationResponse` (AC: 4)
+  - [ ] Marcar `data` como opcional y sus campos como opcionales
+- [ ] Actualizar `adapter.syncLead()` para tolerar `data` ausente en la response (AC: 3)
+  - [ ] Si `response.data?.id` es `undefined`, usar un fallback como `'unknown'` o loguear una advertencia
+  - [ ] Si `response.data?.referencia` o `estado` no existen, omitirlos del metadata
+- [ ] Ejecutar tests unitarios existentes: `npm run test:unit -- src/context/leads`
+
+## Notas de Desarrollo
+
+### `LeadcarsAddCommentRequest` — antes vs después
+
+```typescript
+// ANTES (campos inventados):
+export interface LeadcarsAddCommentRequest {
+  lead_id: number; // ❌ va en la URL, no en el body
+  comentario: string;
+  tipo?: 'NOTA' | 'SEGUIMIENTO' | 'IMPORTANTE'; // ❌ no existe en API
+  privado?: boolean; // ❌ no existe en API
+}
+
+// DESPUÉS (solo lo que acepta la API real):
+export interface LeadcarsAddCommentRequest {
+  comentario: string; // ✅ único campo del body
+}
+```
+
+### `addComment()` en `leadcars-api.service.ts` — antes vs después
+
+```typescript
+// ANTES:
+async addComment(
+  leadId: number,
+  request: Omit<LeadcarsAddCommentRequest, 'lead_id'>,
+  config: LeadcarsConfig,
+): Promise<Result<LeadcarsAddCommentResponse, DomainError>> {
+  const url = `${this.getBaseUrl(config)}/leads/${leadId}/comments`;
+  const payload: LeadcarsAddCommentRequest = {
+    ...request,
+    lead_id: leadId,   // ❌ añadía lead_id al body
+  };
+  return this.executeWithRetry<LeadcarsAddCommentResponse>(
+    () => this.post<LeadcarsAddCommentResponse>(url, payload, config),
+    'addComment',
+  );
+}
+
+// DESPUÉS:
+async addComment(
+  leadId: number,
+  request: LeadcarsAddCommentRequest,  // ✅ sin Omit
+  config: LeadcarsConfig,
+): Promise<Result<LeadcarsAddCommentResponse, DomainError>> {
+  const url = `${this.getBaseUrl(config)}/leads/${leadId}/comments`;
+  // Enviar directamente sin lead_id en el body
+  return this.executeWithRetry<LeadcarsAddCommentResponse>(
+    () => this.post<LeadcarsAddCommentResponse>(url, request, config),
+    'addComment',
+  );
+}
+```
+
+### `LeadcarsCreateLeadResponse` — campos opcionales
+
+La API real de LeadCars v2.4 no documenta explícitamente el formato de respuesta del `POST /leads`. El código actual asume una estructura específica. Para no romper el adapter si la respuesta cambia, marcar los campos de `data` como opcionales:
+
+```typescript
+export interface LeadcarsCreateLeadResponse {
+  success: boolean;
+  data?: {
+    id?: number; // ✅ opcional
+    referencia?: string; // ✅ opcional
+    nombre?: string; // ✅ opcional
+    email?: string; // ✅ opcional
+    telefono?: string; // ✅ opcional
+    estado?: string; // ✅ opcional
+    created_at?: string; // ✅ opcional
+    updated_at?: string; // ✅ opcional
+  };
+  error?: {
+    code?: string;
+    message: string;
+    details?: Record<string, string[]>;
+  };
+}
+```
+
+### Actualizar `syncLead()` en el adapter para tolerar `data` ausente
+
+```typescript
+// ANTES (en leadcars-crm-sync.adapter.ts línea 73-94):
+const response = result.unwrap();
+if (!response.success || !response.data) {
+  const errorMsg = response.error?.message || 'Respuesta sin datos';
+  return err(
+    new LeadSyncFailedError(contactData.visitorId, 'leadcars', errorMsg),
+  );
+}
+this.logger.log(
+  `Lead sincronizado exitosamente: ${response.data.id} (ref: ${response.data.referencia})`,
+);
+return ok({
+  externalLeadId: response.data.id.toString(), // ❌ puede fallar si id es undefined
+  metadata: {
+    referencia: response.data.referencia,
+    estado: response.data.estado,
+    createdAt: response.data.created_at,
+  },
+});
+
+// DESPUÉS (tolerante a data parcial):
+const response = result.unwrap();
+if (!response.success) {
+  const errorMsg = response.error?.message || 'LeadCars rechazó el lead';
+  this.logger.error(`LeadCars rechazó el lead: ${errorMsg}`);
+  return err(
+    new LeadSyncFailedError(contactData.visitorId, 'leadcars', errorMsg),
+  );
+}
+
+const externalId = response.data?.id?.toString() ?? 'unknown';
+this.logger.log(
+  `Lead sincronizado exitosamente: ${externalId} (ref: ${response.data?.referencia ?? 'N/A'})`,
+);
+
+return ok({
+  externalLeadId: externalId,
+  metadata: {
+    ...(response.data?.referencia && { referencia: response.data.referencia }),
+    ...(response.data?.estado && { estado: response.data.estado }),
+    ...(response.data?.created_at && { createdAt: response.data.created_at }),
+  },
+});
+```
+
+### Callers de `addComment` en el adapter
+
+Buscar usos de `addComment` en el adapter y actualizar la firma del call. Actualmente en `leadcars-crm-sync.adapter.ts` no hay una llamada directa visible a `addComment` (se llama desde el API service), pero si hay un método público en el adapter que lo use, actualizar también.
+
+### Archivos a tocar
+
+| Archivo                                                               | Acción                                                                         |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `leads/infrastructure/adapters/leadcars/leadcars.types.ts`            | Simplificar `LeadcarsAddCommentRequest`, marcar campos opcionales en responses |
+| `leads/infrastructure/adapters/leadcars/leadcars-api.service.ts`      | Actualizar `addComment()` — eliminar spread con `lead_id` en body              |
+| `leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts` | Actualizar `syncLead()` para tolerar `data` parcial o ausente                  |
+
+### Dependencias
+
+- Puede implementarse en paralelo con Stories 4.2 y 4.3 (no modifica los mismos tipos)
+- Debe completarse antes de Story 4.6 (los tests E2E verificarán estos tipos)
+
+### Referencias
+
+- Tipos actuales: `src/context/leads/infrastructure/adapters/leadcars/leadcars.types.ts` líneas 123-145
+- API service actual: `src/context/leads/infrastructure/adapters/leadcars/leadcars-api.service.ts` líneas 69-84
+- Adapter `syncLead()`: `src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts` líneas 73-94
+- AGENTS.md discrepancias: `src/context/leads/AGENTS.md` sección "Discrepancias Conocidas"
+- Epics story 4.4: `_bmad-output/planning-artifacts/epics.md` líneas 756-783
+
+## Registro del Agente Dev
+
+### Modelo Utilizado
+
+claude-sonnet-4.6 (github-copilot/claude-sonnet-4.6)
+
+### Notas de Completación
+
+### Lista de Ficheros

--- a/_bmad-output/implementation-artifacts/4-5-integracion-modulo-automagic-journeys.md
+++ b/_bmad-output/implementation-artifacts/4-5-integracion-modulo-automagic-journeys.md
@@ -1,0 +1,296 @@
+# Historia 4.5: Integración con Módulo Automagic (Journeys)
+
+Status: ready-for-dev
+
+## Historia
+
+Como administrador,
+quiero poder asignar leads sincronizados a flujos de nurturing (Automagic) de LeadCars,
+para automatizar el seguimiento de leads tras su captura inicial.
+
+> **IMPORTANTE**: Automagic es un módulo opcional. No todos los clientes de LeadCars lo tienen contratado.
+> Este módulo usa autenticación diferente al resto de la API: headers `api-user` (email) + `api-token`.
+
+## Criterios de Aceptación
+
+1. **Dado** una empresa con Automagic contratado y configurado (`automagicUser` + `automagicToken` en la config)
+   **Cuando** un lead se sincroniza exitosamente con LeadCars
+   **Y** la config tiene `defaultJourneyId` definido
+   **Entonces** el sistema intenta asignar el lead al flujo configurado
+   **Y** el resultado de la asignación se registra en el log (sin bloquear el sync del lead)
+
+2. **Dado** una empresa sin Automagic configurado (sin `automagicUser` o sin `automagicToken`)
+   **Cuando** se sincroniza un lead
+   **Entonces** la asignación a journeys se omite silenciosamente (no es un error)
+   **Y** el sync del lead continúa normalmente
+
+3. **Dado** una llamada a `listJourneys(config)`
+   **Cuando** se ejecuta con credenciales Automagic válidas
+   **Entonces** retorna `Result<LeadcarsJourney[], DomainError>` con `id` y `title` por cada flujo
+
+4. **Dado** una llamada a `addLeadToJourney(externalLeadId, journeyId, config)`
+   **Cuando** el lead ya pasó por el flujo (`409 CONFLICT`)
+   **Entonces** se retorna `ok(void)` (no es un error fatal — el lead ya fue procesado)
+   **Y** se emite un log de advertencia indicando que el lead ya pasó por el flujo
+
+5. **Dado** una llamada a `addLeadToJourney(externalLeadId, journeyId, config)`
+   **Cuando** el lead está actualmente en el flujo (`400 BAD REQUEST`)
+   **Entonces** se retorna `ok(void)` (no es un error — el lead ya está en proceso)
+   **Y** se emite un log de advertencia
+
+6. **Dado** una llamada a `addLeadToJourney(externalLeadId, journeyId, config)`
+   **Cuando** el lead o flujo no existen (`404 NOT FOUND`)
+   **Entonces** se retorna `err(CrmApiError)` (sí es un error que debe registrarse)
+
+7. **Dado** una llamada a `getLeadJourneys(externalLeadId, config)`
+   **Cuando** se ejecuta con credenciales válidas
+   **Entonces** retorna `Result<LeadcarsJourneyLeadStatus[], DomainError>` con el estado del lead en cada flujo
+
+8. **Dado** la config de LeadCars
+   **Cuando** se guarda con campos `automagicUser` y `automagicToken`
+   **Entonces** estos campos se almacenan y se encriptan igual que `clienteToken` (si Story 2.5 está implementada)
+
+## Tareas / Subtareas
+
+- [ ] Añadir nuevos tipos en `leadcars.types.ts` (AC: 3, 7)
+  - [ ] `LeadcarsJourney`: `{ id: string | number; title: string; [key: string]: unknown }`
+  - [ ] `LeadcarsJourneyLeadStatus`: `{ journeyId: string | number; status: string; [key: string]: unknown }`
+  - [ ] `LeadcarsListJourneysResponse`: `{ data?: LeadcarsJourney[] }` o wrapping similar
+  - [ ] `LeadcarsAddLeadToJourneyRequest`: `{ lead_id: string | number; journey_id: string | number }`
+  - [ ] `LeadcarsAddLeadToJourneyResponse`: `{ success?: boolean; [key: string]: unknown }`
+  - [ ] `LeadcarsGetLeadJourneysResponse`: `{ data?: LeadcarsJourneyLeadStatus[] }`
+- [ ] Añadir campos opcionales en `LeadcarsConfig` (AC: 2, 8)
+  - [ ] `automagicUser?: string` — email del usuario Automagic
+  - [ ] `automagicToken?: string` — token de autenticación Automagic
+  - [ ] `defaultJourneyId?: string | number` — ID del flujo para auto-asignación
+- [ ] Implementar métodos Automagic en `leadcars-api.service.ts` (AC: 3, 4, 5, 6, 7)
+  - [ ] `listJourneys(config: LeadcarsConfig): Promise<Result<LeadcarsListJourneysResponse, DomainError>>`
+    - URL: `GET /journeys/list/summary`
+    - Headers: `api-user: config.automagicUser` + `api-token: config.automagicToken`
+  - [ ] `addLeadToJourney(externalLeadId: string, journeyId: string | number, config: LeadcarsConfig): Promise<Result<void, DomainError>>`
+    - URL: `POST /journeys/generate-lead-journey`
+    - Body: `{ lead_id: externalLeadId, journey_id: journeyId }`
+    - Headers: `api-user` + `api-token`
+    - Manejar 409 y 400 como `ok(void)`
+  - [ ] `getLeadJourneys(externalLeadId: string, config: LeadcarsConfig): Promise<Result<LeadcarsGetLeadJourneysResponse, DomainError>>`
+    - URL: `GET /journeys/list/get-lead-journeys` (verificar si lleva query param)
+    - Headers: `api-user` + `api-token`
+  - [ ] Método privado `getAutomagicHeaders(config: LeadcarsConfig)`: retorna `{ 'api-user': ..., 'api-token': ... }`
+- [ ] Actualizar `leadcars-crm-sync.adapter.ts` — auto-asignación post-sync (AC: 1, 2)
+  - [ ] En `syncLead()`, después del sync exitoso:
+    - [ ] Comprobar si `config.automagicUser` y `config.automagicToken` y `config.defaultJourneyId` están presentes
+    - [ ] Si están: llamar a `this.apiService.addLeadToJourney(externalLeadId, config.defaultJourneyId, leadcarsConfig)`
+    - [ ] Loguear resultado (éxito, advertencia 409/400, o error 404)
+    - [ ] Si no están: omitir silenciosamente
+  - [ ] El resultado de la asignación al journey **NO** debe afectar el retorno de `syncLead()` (el lead ya sincronizó bien)
+- [ ] Escribir tests unitarios para los nuevos métodos (AC: 1-7)
+  - [ ] Test: `listJourneys` usa headers correctos (`api-user`, `api-token`)
+  - [ ] Test: `addLeadToJourney` con 409 retorna `ok(void)`
+  - [ ] Test: `addLeadToJourney` con 400 retorna `ok(void)`
+  - [ ] Test: `addLeadToJourney` con 404 retorna `err(...)`
+  - [ ] Test: `syncLead` con `defaultJourneyId` llama a `addLeadToJourney` tras sync exitoso
+  - [ ] Test: `syncLead` sin `automagicUser` no llama a `addLeadToJourney`
+- [ ] Ejecutar tests: `npm run test:unit -- src/context/leads`
+
+## Notas de Desarrollo
+
+### Nuevos campos en `LeadcarsConfig`
+
+```typescript
+export interface LeadcarsConfig {
+  clienteToken: string;
+  useSandbox: boolean;
+  concesionarioId: number;
+  sedeId?: number;
+  campanaCode?: string;
+  tipoLeadDefault: number;
+  defaultCountryCode?: string; // De Story 4.3
+  // Automagic (módulo opcional):
+  automagicUser?: string; // ✅ Email del usuario Automagic
+  automagicToken?: string; // ✅ Token de autenticación Automagic
+  defaultJourneyId?: string | number; // ✅ ID del flujo para auto-asignación
+}
+```
+
+### Nuevos tipos
+
+```typescript
+// Flujo de nurturing de Automagic
+export interface LeadcarsJourney {
+  id: string | number;
+  title: string;
+  [key: string]: unknown; // Campos adicionales que pueda devolver la API
+}
+
+// Estado del lead en un flujo
+export interface LeadcarsJourneyLeadStatus {
+  journeyId: string | number;
+  status: string;
+  [key: string]: unknown;
+}
+
+// Request para añadir lead a journey
+export interface LeadcarsAddLeadToJourneyRequest {
+  lead_id: string | number;
+  journey_id: string | number;
+}
+
+// Responses (opacas — la API no documenta estructura exacta)
+export interface LeadcarsListJourneysResponse {
+  data?: LeadcarsJourney[];
+  [key: string]: unknown;
+}
+
+export interface LeadcarsGetLeadJourneysResponse {
+  data?: LeadcarsJourneyLeadStatus[];
+  [key: string]: unknown;
+}
+```
+
+### Headers de Automagic vs Headers normales
+
+```typescript
+// En LeadcarsApiService:
+
+// Headers normales (todos los endpoints excepto Automagic):
+private getHeaders(config: LeadcarsConfig): Record<string, string> {
+  return {
+    ...LEADCARS_REQUIRED_HEADERS,
+    'cliente-token': config.clienteToken,
+  };
+}
+
+// Headers Automagic (journeys):
+private getAutomagicHeaders(config: LeadcarsConfig): Record<string, string> {
+  return {
+    ...LEADCARS_REQUIRED_HEADERS,
+    'api-user': config.automagicUser!,
+    'api-token': config.automagicToken!,
+  };
+}
+```
+
+### `addLeadToJourney` — manejo especial de 409 y 400
+
+```typescript
+async addLeadToJourney(
+  externalLeadId: string,
+  journeyId: string | number,
+  config: LeadcarsConfig,
+): Promise<Result<void, DomainError>> {
+  const url = `${this.getBaseUrl(config)}/journeys/generate-lead-journey`;
+  const body: LeadcarsAddLeadToJourneyRequest = {
+    lead_id: externalLeadId,
+    journey_id: journeyId,
+  };
+
+  try {
+    const axiosConfig: AxiosRequestConfig = {
+      headers: this.getAutomagicHeaders(config),
+      timeout: 30000,
+    };
+    await firstValueFrom(
+      this.httpService.post(url, body, axiosConfig),
+    );
+    return ok(undefined);
+  } catch (error) {
+    if (error instanceof AxiosError) {
+      const status = error.response?.status;
+      // 409: Ya pasó por el flujo — no es error fatal
+      // 400: Está actualmente en el flujo — no es error fatal
+      if (status === 409 || status === 400) {
+        this.logger.warn(
+          `Lead ${externalLeadId} ya en journey ${journeyId}: HTTP ${status}`,
+        );
+        return ok(undefined);
+      }
+    }
+    return this.handleAxiosError(error, 'POST', url);
+  }
+}
+```
+
+### Auto-asignación en `syncLead()` del adapter
+
+```typescript
+// Al final de syncLead(), después de return ok({...}):
+// ⚠️ No cambiar el valor de retorno — la asignación es best-effort
+
+// Añadir método privado:
+private async tryAssignToDefaultJourney(
+  externalLeadId: string,
+  config: LeadcarsConfig,
+): Promise<void> {
+  if (!config.automagicUser || !config.automagicToken || !config.defaultJourneyId) {
+    return; // Sin configuración Automagic — silencioso
+  }
+
+  this.logger.log(
+    `Intentando asignar lead ${externalLeadId} al journey ${config.defaultJourneyId}`,
+  );
+
+  const result = await this.apiService.addLeadToJourney(
+    externalLeadId,
+    config.defaultJourneyId,
+    config,
+  );
+
+  if (result.isErr()) {
+    this.logger.warn(
+      `No se pudo asignar lead ${externalLeadId} al journey: ${result.error.message}`,
+    );
+  } else {
+    this.logger.log(
+      `Lead ${externalLeadId} asignado al journey ${config.defaultJourneyId}`,
+    );
+  }
+}
+```
+
+Y en `syncLead()`, después del `return ok(syncResult)`:
+
+```typescript
+// Nota: Este bloque va ANTES del return, pero el resultado no afecta el retorno
+const syncResult = {
+  externalLeadId: externalId,
+  metadata: { ... },
+};
+
+// Best-effort: asignar a journey si está configurado (no bloquea ni falla el sync)
+void this.tryAssignToDefaultJourney(externalId, leadcarsConfig);
+
+return ok(syncResult);
+```
+
+> **Nota sobre floating promise**: El linter puede advertir sobre el `void this.tryAssignToDefaultJourney(...)`. Esto es intencional — la asignación al journey es best-effort y no debe bloquear ni fallar el sync principal. El prefijo `void` es la forma correcta de indicarlo.
+
+### Dependencias
+
+- **Depende de Story 4.1**: `LeadcarsConfig` ya tiene los campos actualizados
+- **Puede implementarse en paralelo con 4.2, 4.3, 4.4**: no modifica tipos compartidos
+- Story 2.5 (encriptación): Si está implementada, `automagicToken` también debe encriptarse en MongoDB. Sin embargo, esta story no modifica la capa de persistencia — solo añade los campos al tipo `LeadcarsConfig`. La encriptación/desencriptación se maneja en la capa de repositorio (ver Story 2.5).
+
+### Archivos a tocar
+
+| Archivo                                                               | Acción                                                                                      |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `leads/infrastructure/adapters/leadcars/leadcars.types.ts`            | Añadir nuevos tipos Automagic y campos a `LeadcarsConfig`                                   |
+| `leads/infrastructure/adapters/leadcars/leadcars-api.service.ts`      | Añadir métodos `listJourneys`, `addLeadToJourney`, `getLeadJourneys`, `getAutomagicHeaders` |
+| `leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts` | Añadir `tryAssignToDefaultJourney`, llamar desde `syncLead`                                 |
+
+### Referencias
+
+- Endpoints Automagic: `src/context/leads/AGENTS.md` sección "Módulo Automagic"
+- Epics story 4.5: `_bmad-output/planning-artifacts/epics.md` líneas 785-823
+- API service actual: `src/context/leads/infrastructure/adapters/leadcars/leadcars-api.service.ts`
+- Errores 409/400/404 de Automagic: `src/context/leads/AGENTS.md` sección "Errores Automagic"
+
+## Registro del Agente Dev
+
+### Modelo Utilizado
+
+claude-sonnet-4.6 (github-copilot/claude-sonnet-4.6)
+
+### Notas de Completación
+
+### Lista de Ficheros

--- a/_bmad-output/implementation-artifacts/4-6-tests-e2e-contra-sandbox-leadcars.md
+++ b/_bmad-output/implementation-artifacts/4-6-tests-e2e-contra-sandbox-leadcars.md
@@ -1,0 +1,355 @@
+# Historia 4.6: Tests E2E contra Sandbox de LeadCars
+
+Status: ready-for-dev
+
+## Historia
+
+Como desarrollador,
+quiero tests de integración que ejecuten llamadas reales contra el sandbox de LeadCars para verificar que los tipos y el mapeo de campos son correctos tras la alineación con v2.4,
+para detectar discrepancias antes de llegar a producción.
+
+> **IMPORTANTE**: Estos tests requieren credenciales reales del sandbox de LeadCars configuradas en variables de entorno. Deben ejecutarse manualmente o en CI con las variables de entorno correspondientes, NO en el pipeline de tests unitarios (`npm run test:unit`).
+
+## Criterios de Aceptación
+
+1. **Dado** credenciales de sandbox válidas en variables de entorno (`LEADCARS_SANDBOX_TOKEN`, `LEADCARS_SANDBOX_CONCESIONARIO_ID`, etc.)
+   **Cuando** se ejecuta `POST /leads` con el payload construido por `buildCreateLeadRequest`
+   **Entonces** LeadCars sandbox acepta el lead sin errores de validación (HTTP 200 o 201)
+   **Y** la response parsea correctamente con el tipo `LeadcarsCreateLeadResponse`
+
+2. **Dado** un lead creado exitosamente en sandbox
+   **Cuando** se ejecuta `POST /leads/{id}/chat_conversation` con la nueva estructura v2.4
+   **Entonces** LeadCars sandbox acepta la conversación sin errores
+   **Y** la response parsea correctamente con `LeadcarsAddConversationResponse`
+
+3. **Dado** un lead creado exitosamente en sandbox
+   **Cuando** se ejecuta `POST /leads/{id}/comments` con `{ comentario: "test E2E" }`
+   **Entonces** LeadCars sandbox acepta el comentario
+   **Y** la response parsea correctamente con `LeadcarsAddCommentResponse`
+
+4. **Dado** credenciales de sandbox válidas
+   **Cuando** se ejecuta `GET /concesionarios`
+   **Entonces** la response parsea correctamente con `LeadcarsListConcesionariosResponse`
+   **Y** retorna al menos un concesionario con `id` y `nombre`
+
+5. **Dado** un `concesionarioId` válido del sandbox
+   **Cuando** se ejecuta `GET /sedes/{concesionarioId}`
+   **Entonces** la response parsea correctamente con `LeadcarsListSedesResponse`
+
+6. **Dado** un `concesionarioId` válido del sandbox
+   **Cuando** se ejecuta `GET /campanas/{concesionarioId}`
+   **Entonces** la response parsea correctamente con `LeadcarsListCampanasResponse`
+
+7. **Dado** credenciales de sandbox válidas
+   **Cuando** se ejecuta `GET /tipos`
+   **Entonces** la response parsea correctamente con `LeadcarsListTiposResponse`
+   **Y** retorna al menos un tipo con `id` y `nombre`
+
+8. **Dado** credenciales Automagic de sandbox (si disponibles: `LEADCARS_SANDBOX_AUTOMAGIC_USER`, `LEADCARS_SANDBOX_AUTOMAGIC_TOKEN`)
+   **Cuando** se ejecuta `GET /journeys/list/summary`
+   **Entonces** la response parsea correctamente con `LeadcarsListJourneysResponse`
+
+## Tareas / Subtareas
+
+- [ ] Crear el archivo de test: `src/context/leads/infrastructure/adapters/leadcars/__tests__/leadcars-api.e2e.spec.ts`
+- [ ] Configurar el test module con `LeadcarsApiService` e `HttpModule` real (sin mocks)
+- [ ] Implementar `beforeAll` — inicializar módulo y verificar variables de entorno
+  - [ ] Si `LEADCARS_SANDBOX_TOKEN` no está definida, saltar todos los tests con `test.skip`
+  - [ ] Leer `LEADCARS_SANDBOX_CONCESIONARIO_ID` para los tests de discovery
+- [ ] Test de `POST /leads` — crear lead de prueba (AC: 1)
+  - [ ] Construir payload con campos correctos post-Story 4.1: `concesionario`, `tipo_lead` (número), etc.
+  - [ ] Guardar el `externalLeadId` resultante para los tests subsiguientes
+- [ ] Test de `POST /leads/{id}/chat_conversation` — estructura v2.4 (AC: 2)
+  - [ ] Construir payload con estructura `{ chat: { chat_id, users[], messages[] } }`
+  - [ ] Verificar que la respuesta es exitosa
+- [ ] Test de `POST /leads/{id}/comments` — solo `{ comentario }` (AC: 3)
+  - [ ] Enviar `{ comentario: 'Test E2E automatizado desde Guiders' }`
+  - [ ] Verificar que la respuesta es exitosa
+- [ ] Tests de discovery: `listConcesionarios`, `listSedes`, `listCampanas`, `listTipos` (AC: 4-7)
+  - [ ] Verificar que la response no es `null`/`undefined`
+  - [ ] Verificar que la estructura de datos parsea sin error
+- [ ] Test de Automagic (condicional) — solo si hay variables de entorno (AC: 8)
+  - [ ] Saltar si `LEADCARS_SANDBOX_AUTOMAGIC_USER` no está definida
+  - [ ] Verificar `listJourneys` retorna sin error
+
+## Notas de Desarrollo
+
+### Archivo y configuración del test
+
+```typescript
+// src/context/leads/infrastructure/adapters/leadcars/__tests__/leadcars-api.e2e.spec.ts
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpModule } from '@nestjs/axios';
+import { LeadcarsApiService } from '../leadcars-api.service';
+import { LeadcarsConfig } from '../leadcars.types';
+
+/**
+ * Tests E2E contra el sandbox real de LeadCars.
+ * Requieren variables de entorno:
+ *   - LEADCARS_SANDBOX_TOKEN: token de autenticación (20 chars)
+ *   - LEADCARS_SANDBOX_CONCESIONARIO_ID: ID del concesionario de prueba
+ *   - LEADCARS_SANDBOX_TIPO_LEAD_ID: ID del tipo de lead (de GET /tipos)
+ *   - LEADCARS_SANDBOX_AUTOMAGIC_USER: (opcional) email para Automagic
+ *   - LEADCARS_SANDBOX_AUTOMAGIC_TOKEN: (opcional) token para Automagic
+ */
+describe('LeadcarsApiService — E2E Sandbox', () => {
+  let service: LeadcarsApiService;
+  let sandboxConfig: LeadcarsConfig;
+  let createdLeadId: string;
+
+  const hasSandboxCredentials = !!process.env.LEADCARS_SANDBOX_TOKEN;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [HttpModule],
+      providers: [LeadcarsApiService],
+    }).compile();
+
+    service = module.get<LeadcarsApiService>(LeadcarsApiService);
+
+    sandboxConfig = {
+      clienteToken: process.env.LEADCARS_SANDBOX_TOKEN ?? '',
+      useSandbox: true,
+      concesionarioId: parseInt(
+        process.env.LEADCARS_SANDBOX_CONCESIONARIO_ID ?? '0',
+        10,
+      ),
+      tipoLeadDefault: parseInt(
+        process.env.LEADCARS_SANDBOX_TIPO_LEAD_ID ?? '1',
+        10,
+      ),
+    };
+  });
+
+  describe('cuando las credenciales de sandbox no están disponibles', () => {
+    it('se deben configurar las variables de entorno para ejecutar estos tests', () => {
+      if (!hasSandboxCredentials) {
+        console.warn(
+          'Tests E2E de LeadCars sandbox omitidos. ' +
+            'Configura LEADCARS_SANDBOX_TOKEN para ejecutarlos.',
+        );
+      }
+      expect(true).toBe(true); // Test siempre pasa — solo es informativo
+    });
+  });
+
+  // Los tests reales solo se registran si hay credenciales
+  if (hasSandboxCredentials) {
+    describe('Discovery', () => {
+      it('debe listar concesionarios correctamente', async () => {
+        const result = await service.listConcesionarios(sandboxConfig);
+        expect(result.isOk()).toBe(true);
+        // Parseo válido — no lanza excepción
+      });
+
+      it('debe listar tipos de lead correctamente', async () => {
+        const result = await service.listTipos(sandboxConfig);
+        expect(result.isOk()).toBe(true);
+      });
+
+      it('debe listar sedes del concesionario correctamente', async () => {
+        const result = await service.listSedes(
+          sandboxConfig.concesionarioId,
+          sandboxConfig,
+        );
+        expect(result.isOk()).toBe(true);
+      });
+
+      it('debe listar campañas del concesionario correctamente', async () => {
+        const result = await service.listCampanas(
+          sandboxConfig.concesionarioId,
+          sandboxConfig,
+        );
+        expect(result.isOk()).toBe(true);
+      });
+    });
+
+    describe('Crear lead', () => {
+      it('debe crear un lead con los campos correctos de v2.4', async () => {
+        const result = await service.createLead(
+          {
+            nombre: 'Test E2E',
+            apellidos: 'Guiders Autotest',
+            email: `e2e-test-${Date.now()}@guiders-test.com`,
+            concesionario: sandboxConfig.concesionarioId,
+            tipo_lead: sandboxConfig.tipoLeadDefault,
+            comentario: 'Lead creado automáticamente por test E2E de Guiders',
+          },
+          sandboxConfig,
+        );
+
+        expect(result.isOk()).toBe(true);
+
+        if (result.isOk()) {
+          const response = result.unwrap();
+          // Guardar ID para tests subsiguientes
+          if (response.data?.id) {
+            createdLeadId = response.data.id.toString();
+          }
+        }
+      });
+    });
+
+    describe('Chat conversation', () => {
+      it('debe registrar una conversación con estructura v2.4', async () => {
+        if (!createdLeadId) {
+          console.warn('Omitiendo test de chat: no hay lead creado en sandbox');
+          return;
+        }
+
+        const chatId = `e2e-chat-${Date.now()}`;
+        const visitorId = 'visitor-e2e-test';
+        const now = new Date().toISOString();
+
+        const result = await service.addChatConversation(
+          parseInt(createdLeadId, 10),
+          {
+            chat: {
+              chat_id: chatId,
+              users: [
+                {
+                  _id: 'commercial',
+                  user: { id: 'commercial', name: 'Agente Test' },
+                },
+                {
+                  _id: visitorId,
+                  visitor: { id: visitorId, name: 'Visitante Test' },
+                },
+              ],
+              messages: [
+                {
+                  _id: `${chatId}-msg-0`,
+                  message: {
+                    text: '¡Hola! ¿En qué puedo ayudarte?',
+                    type: 'text',
+                  },
+                  created_at: now,
+                  user_sender: 'commercial',
+                  interaction_type: 'welcome',
+                },
+                {
+                  _id: `${chatId}-msg-1`,
+                  message: {
+                    text: 'Gracias por tu interés. Hasta pronto.',
+                    type: 'text',
+                  },
+                  created_at: now,
+                  user_sender: 'commercial',
+                  interaction_type: 'close',
+                },
+              ],
+            },
+          },
+          sandboxConfig,
+        );
+
+        expect(result.isOk()).toBe(true);
+      });
+    });
+
+    describe('Comentarios', () => {
+      it('debe añadir un comentario solo con { comentario }', async () => {
+        if (!createdLeadId) {
+          console.warn(
+            'Omitiendo test de comentario: no hay lead creado en sandbox',
+          );
+          return;
+        }
+
+        const result = await service.addComment(
+          parseInt(createdLeadId, 10),
+          { comentario: 'Comentario de test E2E desde Guiders' },
+          sandboxConfig,
+        );
+
+        expect(result.isOk()).toBe(true);
+      });
+    });
+
+    describe('Automagic (condicional)', () => {
+      const hasAutomagic = !!(
+        process.env.LEADCARS_SANDBOX_AUTOMAGIC_USER &&
+        process.env.LEADCARS_SANDBOX_AUTOMAGIC_TOKEN
+      );
+
+      it('debe listar journeys si hay credenciales Automagic', async () => {
+        if (!hasAutomagic) {
+          console.info(
+            'Test Automagic omitido: sin credenciales Automagic en env',
+          );
+          return;
+        }
+
+        const configConAutomagic: LeadcarsConfig = {
+          ...sandboxConfig,
+          automagicUser: process.env.LEADCARS_SANDBOX_AUTOMAGIC_USER,
+          automagicToken: process.env.LEADCARS_SANDBOX_AUTOMAGIC_TOKEN,
+        };
+
+        const result = await service.listJourneys(configConAutomagic);
+        expect(result.isOk()).toBe(true);
+      });
+    });
+  } // end if hasSandboxCredentials
+});
+```
+
+### Cómo ejecutar estos tests
+
+```bash
+# Configurar variables de entorno (o en un archivo .env.test.local ignorado por git)
+export LEADCARS_SANDBOX_TOKEN="tu_token_de_sandbox"
+export LEADCARS_SANDBOX_CONCESIONARIO_ID="123"
+export LEADCARS_SANDBOX_TIPO_LEAD_ID="1"
+
+# Ejecutar solo los tests E2E de LeadCars
+npm run test:unit -- src/context/leads/infrastructure/adapters/leadcars/__tests__/leadcars-api.e2e.spec.ts
+
+# O con jest directamente para ver output detallado
+npx jest leadcars-api.e2e.spec.ts --verbose --no-coverage
+```
+
+> **NO incluir** las variables de entorno en el repositorio. Usar un archivo `.env.test.local` o configurarlas directamente en la terminal.
+
+### Dependencias de Stories anteriores
+
+Estos tests **validan las implementaciones de las Stories 4.1 a 4.5**. Deben ejecutarse después de que todas las stories del Epic 4 estén implementadas:
+
+| Dependencia | Qué valida                                                             |
+| ----------- | ---------------------------------------------------------------------- |
+| Story 4.1   | Campo `concesionario` (no `concesionario_id`), `tipo_lead` como número |
+| Story 4.2   | Estructura `{ chat: { chat_id, users[], messages[] } }`                |
+| Story 4.3   | Teléfono en E.164 (si se añade en el payload de prueba)                |
+| Story 4.4   | Request de comentario solo con `{ comentario }`                        |
+| Story 4.5   | `listJourneys` con headers `api-user` + `api-token`                    |
+
+### Nota sobre el runner de tests
+
+El archivo usa el patrón de `if (hasSandboxCredentials)` para registrar tests condicionalmente. Esto evita que los tests fallen en CI si las variables no están configuradas, sin necesidad de un runner separado.
+
+Alternativa: añadir `testPathIgnorePatterns` en `jest.config.ts` para los archivos `.e2e.spec.ts` del contexto leads si se quiere separación más formal.
+
+### Archivos a crear/modificar
+
+| Archivo                                                                     | Acción        |
+| --------------------------------------------------------------------------- | ------------- |
+| `leads/infrastructure/adapters/leadcars/__tests__/leadcars-api.e2e.spec.ts` | Crear (nuevo) |
+
+### Referencias
+
+- API service: `src/context/leads/infrastructure/adapters/leadcars/leadcars-api.service.ts`
+- Tipos: `src/context/leads/infrastructure/adapters/leadcars/leadcars.types.ts`
+- AGENTS.md API v2.4: `src/context/leads/AGENTS.md`
+- Test pattern referencia: `src/context/leads/application/commands/__tests__/save-lead-contact-data-command.handler.spec.ts`
+- Epics story 4.6: `_bmad-output/planning-artifacts/epics.md` líneas 825-849
+
+## Registro del Agente Dev
+
+### Modelo Utilizado
+
+claude-sonnet-4.6 (github-copilot/claude-sonnet-4.6)
+
+### Notas de Completación
+
+### Lista de Ficheros

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,6 @@
+# Deferred Work
+
+## Deferred from: code review of story-4.1 (2026-04-01)
+
+- Sin validación de `concesionarioId` en URL path (`leadcars-api.service.ts:122`): El ID del concesionario se interpola directamente en la URL sin validar que sea un número positivo. Pre-existente: `listSedes` tiene el mismo patrón.
+- email y apellidos requeridos por API v2.4 pero no validados/advertidos: La API de LeadCars marca `email` y `apellidos` como requeridos pero el adapter no valida su presencia antes de enviar. Pre-existente: nunca se validó.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -36,7 +36,7 @@
 # - Stories marcadas 'done' fueron implementadas antes de la creación formal de épicas (brownfield reconciliation)
 
 generated: 30/03/2026
-last_updated: 01/04/2026 (4.1 review)
+last_updated: 01/04/2026 (4.1 done)
 project: guiders-backend
 project_key: NOKEY
 tracking_system: file-system
@@ -46,7 +46,7 @@ story_location: _bmad-output/implementation-artifacts
 # Epic 1: Intereses del Visitante (backlog) — 0/2 stories
 # Epic 2: Config CRM y Admin LeadCars (in-progress) — 4/5 stories done, 1 ready-for-dev
 # Epic 3: Datos Contacto y Sync CRM (in-progress) — 4/5 stories done, 1 ready-for-dev
-# Epic 4: Alineación API LeadCars v2.4 (in-progress) — 0/6 done, 6 ready-for-dev
+# Epic 4: Alineación API LeadCars v2.4 (in-progress) — 1/6 done, 5 ready-for-dev
 
 development_status:
   # ─────────────────────────────────────────────────────────────
@@ -97,7 +97,7 @@ development_status:
   # Prioridad: Alta — los campos actuales no coinciden con la API
   # ─────────────────────────────────────────────────────────────
   epic-4: in-progress
-  4-1-corregir-tipos-y-request-crear-lead: review
+  4-1-corregir-tipos-y-request-crear-lead: done
   4-2-alinear-estructura-chat-conversation-api-v24: ready-for-dev
   4-3-validacion-formato-e164-telefonos: ready-for-dev
   4-4-actualizar-tipos-response-y-comentarios: ready-for-dev

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -36,7 +36,7 @@
 # - Stories marcadas 'done' fueron implementadas antes de la creación formal de épicas (brownfield reconciliation)
 
 generated: 30/03/2026
-last_updated: 30/03/2026
+last_updated: 01/04/2026 (4.1 review)
 project: guiders-backend
 project_key: NOKEY
 tracking_system: file-system
@@ -44,9 +44,9 @@ story_location: _bmad-output/implementation-artifacts
 
 # SPRINT OVERVIEW:
 # Epic 1: Intereses del Visitante (backlog) — 0/2 stories
-# Epic 2: Config CRM y Admin LeadCars (in-progress) — 4/5 stories done
-# Epic 3: Datos Contacto y Sync CRM (in-progress) — 4/5 stories done
-# Epic 4: Alineación API LeadCars v2.4 (backlog) — 0/6 stories
+# Epic 2: Config CRM y Admin LeadCars (in-progress) — 4/5 stories done, 1 ready-for-dev
+# Epic 3: Datos Contacto y Sync CRM (in-progress) — 4/5 stories done, 1 ready-for-dev
+# Epic 4: Alineación API LeadCars v2.4 (in-progress) — 0/6 done, 6 ready-for-dev
 
 development_status:
   # ─────────────────────────────────────────────────────────────
@@ -71,7 +71,7 @@ development_status:
   2-2-cliente-http-leadcars-con-retry: done
   2-3-proxy-discovery-datos-leadcars: done
   2-4-endpoints-test-conexion-crm: done
-  2-5-encriptacion-en-reposo-api-keys-crm: backlog
+  2-5-encriptacion-en-reposo-api-keys-crm: ready-for-dev
   epic-2-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────
@@ -85,7 +85,7 @@ development_status:
   3-2-registros-sincronizacion-crm-dashboard: done
   3-3-sincronizacion-automatica-lead-a-crm: done
   3-4-sincronizacion-automatica-chat-a-crm: done
-  3-5-tests-unitarios-sync-lead-y-chat: backlog
+  3-5-tests-unitarios-sync-lead-y-chat: ready-for-dev
   epic-3-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────
@@ -96,11 +96,11 @@ development_status:
   # Fuente de verdad: docs/leadcar/LeadCars_API_V2_4.pdf
   # Prioridad: Alta — los campos actuales no coinciden con la API
   # ─────────────────────────────────────────────────────────────
-  epic-4: backlog
-  4-1-corregir-tipos-y-request-crear-lead: backlog
-  4-2-alinear-estructura-chat-conversation-api-v24: backlog
-  4-3-validacion-formato-e164-telefonos: backlog
-  4-4-actualizar-tipos-response-y-comentarios: backlog
-  4-5-integracion-modulo-automagic-journeys: backlog
-  4-6-tests-e2e-contra-sandbox-leadcars: backlog
+  epic-4: in-progress
+  4-1-corregir-tipos-y-request-crear-lead: review
+  4-2-alinear-estructura-chat-conversation-api-v24: ready-for-dev
+  4-3-validacion-formato-e164-telefonos: ready-for-dev
+  4-4-actualizar-tipos-response-y-comentarios: ready-for-dev
+  4-5-integracion-modulo-automagic-journeys: ready-for-dev
+  4-6-tests-e2e-contra-sandbox-leadcars: ready-for-dev
   epic-4-retrospective: optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,13 +118,13 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "19.2.19",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.19.tgz",
-      "integrity": "sha512-JbLL+4IMLMBgjLZlnPG4lYDfz4zGrJ/s6Aoon321NJKuw1Kb1k5KpFu9dUY0BqLIe8xPQ2UJBpI+xXdK5MXMHQ==",
+      "version": "19.2.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.22.tgz",
+      "integrity": "sha512-OqN/Ded+ZKypPZN5+qUFwtnKGl7FKpxJXYO2Vts5vLBojY5goCZd9SGW1CyXeuPnisRUW+vjqBQbWYuEUh36Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "8.17.1",
+        "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
         "picomatch": "4.0.2",
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@angular-devkit/core/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -180,13 +180,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "19.2.19",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.19.tgz",
-      "integrity": "sha512-J4Jarr0SohdrHcb40gTL4wGPCQ952IMWF1G/MSAQfBAPvA9ZKApYhpxcY7PmehVePve+ujpus1dGsJ7dPxz8Kg==",
+      "version": "19.2.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.22.tgz",
+      "integrity": "sha512-tvfu5jhem1o8qidVxvXe5KfCij65ioMLCOFA947DD+zb3yTl5pJyDm2dqzbOehuQw0fmH4XPQukRJsCUy+UwaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.19",
+        "@angular-devkit/core": "19.2.22",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -199,14 +199,14 @@
       }
     },
     "node_modules/@angular-devkit/schematics-cli": {
-      "version": "19.2.19",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.19.tgz",
-      "integrity": "sha512-7q9UY6HK6sccL9F3cqGRUwKhM7b/XfD2YcVaZ2WD7VMaRlRm85v6mRjSrfKIAwxcQU0UK27kMc79NIIqaHjzxA==",
+      "version": "19.2.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-19.2.22.tgz",
+      "integrity": "sha512-6BvkxDz4nV8B6Ha4n/pYZ503vXgLxMaEpcKsFDao1sl0iSwrIOphlIS1yWprlGdCThIM3aJref1JU13ZvEcBCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.19",
-        "@angular-devkit/schematics": "19.2.19",
+        "@angular-devkit/core": "19.2.22",
+        "@angular-devkit/schematics": "19.2.22",
         "@inquirer/prompts": "7.3.2",
         "ansi-colors": "4.1.3",
         "symbol-observable": "4.0.0",
@@ -464,594 +464,580 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.933.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.933.0.tgz",
-      "integrity": "sha512-KxwZvdxdCeWK6o8mpnb+kk7Kgb8V+8AjTwSXUWH1UAD85B0tjdo1cSfE5zoR5fWGol4Ml5RLez12a6LPhsoTqA==",
+      "version": "3.1021.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1021.0.tgz",
+      "integrity": "sha512-BCfggq8gYSjlKOZlMSVApix3cgKAQIWGeoJFX/AU5HMvqz1BZBEw83jJFL9LYrqTPCocH8NGl++1Xr70ro+jcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/credential-provider-node": "3.933.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.930.0",
-        "@aws-sdk/middleware-expect-continue": "3.930.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.932.0",
-        "@aws-sdk/middleware-host-header": "3.930.0",
-        "@aws-sdk/middleware-location-constraint": "3.930.0",
-        "@aws-sdk/middleware-logger": "3.930.0",
-        "@aws-sdk/middleware-recursion-detection": "3.933.0",
-        "@aws-sdk/middleware-sdk-s3": "3.932.0",
-        "@aws-sdk/middleware-ssec": "3.930.0",
-        "@aws-sdk/middleware-user-agent": "3.932.0",
-        "@aws-sdk/region-config-resolver": "3.930.0",
-        "@aws-sdk/signature-v4-multi-region": "3.932.0",
-        "@aws-sdk/types": "3.930.0",
-        "@aws-sdk/util-endpoints": "3.930.0",
-        "@aws-sdk/util-user-agent-browser": "3.930.0",
-        "@aws-sdk/util-user-agent-node": "3.932.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.2",
-        "@smithy/eventstream-serde-browser": "^4.2.5",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
-        "@smithy/eventstream-serde-node": "^4.2.5",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-blob-browser": "^4.2.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/hash-stream-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/md5-js": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.9",
-        "@smithy/middleware-retry": "^4.4.9",
-        "@smithy/middleware-serde": "^4.2.5",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.8",
-        "@smithy/util-defaults-mode-node": "^4.2.11",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.5",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-node": "^3.972.29",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
+        "@aws-sdk/middleware-expect-continue": "^3.972.8",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.6",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-location-constraint": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
+        "@aws-sdk/middleware-ssec": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.15",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-blob-browser": "^4.2.13",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/hash-stream-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/md5-js": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.933.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.933.0.tgz",
-      "integrity": "sha512-zwGLSiK48z3PzKpQiDMKP85+fpIrPMF1qQOQW9OW7BGj5AuBZIisT2O4VzIgYJeh+t47MLU7VgBQL7muc+MJDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/middleware-host-header": "3.930.0",
-        "@aws-sdk/middleware-logger": "3.930.0",
-        "@aws-sdk/middleware-recursion-detection": "3.933.0",
-        "@aws-sdk/middleware-user-agent": "3.932.0",
-        "@aws-sdk/region-config-resolver": "3.930.0",
-        "@aws-sdk/types": "3.930.0",
-        "@aws-sdk/util-endpoints": "3.930.0",
-        "@aws-sdk/util-user-agent-browser": "3.930.0",
-        "@aws-sdk/util-user-agent-node": "3.932.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.2",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.9",
-        "@smithy/middleware-retry": "^4.4.9",
-        "@smithy/middleware-serde": "^4.2.5",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.8",
-        "@smithy/util-defaults-mode-node": "^4.2.11",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.932.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-      "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
+      "version": "3.973.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.26.tgz",
+      "integrity": "sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@aws-sdk/xml-builder": "3.930.0",
-        "@smithy/core": "^3.18.2",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/xml-builder": "^3.972.16",
+        "@smithy/core": "^3.23.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.5.tgz",
+      "integrity": "sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.932.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.932.0.tgz",
-      "integrity": "sha512-ozge/c7NdHUDyHqro6+P5oHt8wfKSUBN+olttiVfBe9Mw3wBMpPa3gQ0pZnG+gwBkKskBuip2bMR16tqYvUSEA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.24.tgz",
+      "integrity": "sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.932.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.932.0.tgz",
-      "integrity": "sha512-b6N9Nnlg8JInQwzBkUq5spNaXssM3h3zLxGzpPrnw0nHSIWPJPTbZzA5Ca285fcDUFuKP+qf3qkuqlAjGOdWhg==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.26.tgz",
+      "integrity": "sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-stream": "^4.5.6",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.21",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.933.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.933.0.tgz",
-      "integrity": "sha512-HygGyKuMG5AaGXsmM0d81miWDon55xwalRHB3UmDg3QBhtunbNIoIaWUbNTKuBZXcIN6emeeEZw/YgSMqLc0YA==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.28.tgz",
+      "integrity": "sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/credential-provider-env": "3.932.0",
-        "@aws-sdk/credential-provider-http": "3.932.0",
-        "@aws-sdk/credential-provider-process": "3.932.0",
-        "@aws-sdk/credential-provider-sso": "3.933.0",
-        "@aws-sdk/credential-provider-web-identity": "3.933.0",
-        "@aws-sdk/nested-clients": "3.933.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-login": "^3.972.28",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.28",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.28.tgz",
+      "integrity": "sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.933.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.933.0.tgz",
-      "integrity": "sha512-L2dE0Y7iMLammQewPKNeEh1z/fdJyYEU+/QsLBD9VEh+SXcN/FIyTi21Isw8wPZN6lMB9PDVtISzBnF8HuSFrw==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
+      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.932.0",
-        "@aws-sdk/credential-provider-http": "3.932.0",
-        "@aws-sdk/credential-provider-ini": "3.933.0",
-        "@aws-sdk/credential-provider-process": "3.932.0",
-        "@aws-sdk/credential-provider-sso": "3.933.0",
-        "@aws-sdk/credential-provider-web-identity": "3.933.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/credential-provider-env": "^3.972.24",
+        "@aws-sdk/credential-provider-http": "^3.972.26",
+        "@aws-sdk/credential-provider-ini": "^3.972.28",
+        "@aws-sdk/credential-provider-process": "^3.972.24",
+        "@aws-sdk/credential-provider-sso": "^3.972.28",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.932.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.932.0.tgz",
-      "integrity": "sha512-BodZYKvT4p/Dkm28Ql/FhDdS1+p51bcZeMMu2TRtU8PoMDHnVDhHz27zASEKSZwmhvquxHrZHB0IGuVqjZUtSQ==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.24.tgz",
+      "integrity": "sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.933.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.933.0.tgz",
-      "integrity": "sha512-/R1DBR7xNcuZIhS2RirU+P2o8E8/fOk+iLAhbqeSTq+g09fP/F6W7ouFpS5eVE2NIfWG7YBFoVddOhvuqpn51g==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.28.tgz",
+      "integrity": "sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.933.0",
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/token-providers": "3.933.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/token-providers": "3.1021.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.933.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.933.0.tgz",
-      "integrity": "sha512-c7Eccw2lhFx2/+qJn3g+uIDWRuWi2A6Sz3PVvckFUEzPsP0dPUo19hlvtarwP5GzrsXn0yEPRVhpewsIaSCGaQ==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.28.tgz",
+      "integrity": "sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/nested-clients": "3.933.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.930.0.tgz",
-      "integrity": "sha512-cnCLWeKPYgvV4yRYPFH6pWMdUByvu2cy2BAlfsPpvnm4RaVioztyvxmQj5PmVN5fvWs5w/2d6U7le8X9iye2sA==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.8.tgz",
+      "integrity": "sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@aws-sdk/util-arn-parser": "3.893.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-config-provider": "^4.2.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.930.0.tgz",
-      "integrity": "sha512-5HEQ+JU4DrLNWeY27wKg/jeVa8Suy62ivJHOSUf6e6hZdVIMx0h/kXS1fHEQNNiLu2IzSEP/bFXsKBaW7x7s0g==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.8.tgz",
+      "integrity": "sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.932.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.932.0.tgz",
-      "integrity": "sha512-hyvRz/XS/0HTHp9/Ld1mKwpOi7bZu5olI42+T112rkCTbt1bewkygzEl4oflY4H7cKMamQusYoL0yBUD/QSEvA==",
+      "version": "3.974.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.6.tgz",
+      "integrity": "sha512-YckB8k1ejbyCg/g36gUMFLNzE4W5cERIa4MtsdO+wpTmJEP0+TB7okWIt7d8TDOvnb7SwvxJ21E4TGOBxFpSWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/crc64-nvme": "^3.972.5",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
-      "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+      "integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.930.0.tgz",
-      "integrity": "sha512-QIGNsNUdRICog+LYqmtJ03PLze6h2KCORXUs5td/hAEjVP5DMmubhtrGg1KhWyctACluUH/E/yrD14p4pRXxwA==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.8.tgz",
+      "integrity": "sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
-      "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+      "integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.933.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.933.0.tgz",
-      "integrity": "sha512-qgrMlkVKzTCAdNw2A05DC2sPBo0KRQ7wk+lbYSRJnWVzcrceJhnmhoZVV5PFv7JtchK7sHVcfm9lcpiyd+XaCA==",
+      "version": "3.972.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+      "integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@aws/lambda-invoke-store": "^0.2.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.932.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.932.0.tgz",
-      "integrity": "sha512-bYMHxqQzseaAP9Z5qLI918z5AtbAnZRRtFi3POb4FLZyreBMgCgBNaPkIhdgywnkqaydTWvbMBX4s9f4gUwlTw==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.27.tgz",
+      "integrity": "sha512-gomO6DZwx+1D/9mbCpcqO5tPBqYBK7DtdgjTIjZ4yvfh/S7ETwAPS0XbJgP2JD8Ycr5CwVrEkV1sFtu3ShXeOw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/types": "3.930.0",
-        "@aws-sdk/util-arn-parser": "3.893.0",
-        "@smithy/core": "^3.18.2",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.930.0.tgz",
-      "integrity": "sha512-N2/SvodmaDS6h7CWfuapt3oJyn1T2CBz0CsDIiTDv9cSagXAVFjPdm2g4PFJqrNBeqdDIoYBnnta336HmamWHg==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.8.tgz",
+      "integrity": "sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.932.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
-      "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.28.tgz",
+      "integrity": "sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/types": "3.930.0",
-        "@aws-sdk/util-endpoints": "3.930.0",
-        "@smithy/core": "^3.18.2",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@smithy/core": "^3.23.13",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-retry": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.933.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.933.0.tgz",
-      "integrity": "sha512-o1GX0+IPlFi/D8ei9y/jj3yucJWNfPnbB5appVBWevAyUdZA5KzQ2nK/hDxiu9olTZlFEFpf1m1Rn3FaGxHqsw==",
+      "version": "3.996.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.18.tgz",
+      "integrity": "sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/middleware-host-header": "3.930.0",
-        "@aws-sdk/middleware-logger": "3.930.0",
-        "@aws-sdk/middleware-recursion-detection": "3.933.0",
-        "@aws-sdk/middleware-user-agent": "3.932.0",
-        "@aws-sdk/region-config-resolver": "3.930.0",
-        "@aws-sdk/types": "3.930.0",
-        "@aws-sdk/util-endpoints": "3.930.0",
-        "@aws-sdk/util-user-agent-browser": "3.930.0",
-        "@aws-sdk/util-user-agent-node": "3.932.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.2",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.9",
-        "@smithy/middleware-retry": "^4.4.9",
-        "@smithy/middleware-serde": "^4.2.5",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.8",
-        "@smithy/util-defaults-mode-node": "^4.2.11",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/region-config-resolver": "^3.972.10",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.14",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/core": "^3.23.13",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-retry": "^4.4.46",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.44",
+        "@smithy/util-defaults-mode-node": "^4.2.48",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
-      "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+      "integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.932.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.932.0.tgz",
-      "integrity": "sha512-NCIRJvoRc9246RZHIusY1+n/neeG2yGhBGdKhghmrNdM+mLLN6Ii7CKFZjx3DhxtpHMpl1HWLTMhdVrGwP2upw==",
+      "version": "3.996.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.15.tgz",
+      "integrity": "sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.932.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.27",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.933.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.933.0.tgz",
-      "integrity": "sha512-Qzq7zj9yXUgAAJEbbmqRhm0jmUndl8nHG0AbxFEfCfQRVZWL96Qzx0mf8lYwT9hIMrXncLwy31HOthmbXwFRwQ==",
+      "version": "3.1021.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1021.0.tgz",
+      "integrity": "sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.932.0",
-        "@aws-sdk/nested-clients": "3.933.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/core": "^3.973.26",
+        "@aws-sdk/nested-clients": "^3.996.18",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-      "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+      "integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
-      "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+      "version": "3.996.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+      "integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-endpoints": "^3.2.5",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-endpoints": "^3.3.3",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
@@ -1067,31 +1053,32 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
-      "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+      "integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.932.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
-      "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.14.tgz",
+      "integrity": "sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.932.0",
-        "@aws-sdk/types": "3.930.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.28",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -1103,23 +1090,23 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.930.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
-      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
-        "fast-xml-parser": "5.2.5",
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.0.tgz",
-      "integrity": "sha512-D1jAmAZQYMoPiacfgNf7AWhg3DFN3Wq/vQv3WINt9znwjzHp2x+WzdJFxxj7xZL7V1U79As6G8f7PorMYWBKsQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -1640,6 +1627,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -2283,29 +2280,6 @@
         }
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2907,9 +2881,9 @@
       }
     },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3329,15 +3303,15 @@
       }
     },
     "node_modules/@nestjs/cli": {
-      "version": "11.0.12",
-      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.12.tgz",
-      "integrity": "sha512-V3fD1xESlFcJ1xpwOtUhn0edLvIa76Sx8mkvdR1s8cM4c/rZO+yGmXP30ZQwPfIJPTgBvsw93F/i+87eV96wcQ==",
+      "version": "11.0.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-11.0.17.tgz",
+      "integrity": "sha512-tOMgoB9k+Zb2WdKYPhbhceROLcDR1BFQZWfkBOGMRgBTo8rnC125E65UvThEA77vp4w+zKjqiSIv0leT+wdpHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.19",
-        "@angular-devkit/schematics": "19.2.19",
-        "@angular-devkit/schematics-cli": "19.2.19",
+        "@angular-devkit/core": "19.2.22",
+        "@angular-devkit/schematics": "19.2.22",
+        "@angular-devkit/schematics-cli": "19.2.22",
         "@inquirer/prompts": "7.10.1",
         "@nestjs/schematics": "^11.0.1",
         "ansis": "4.2.0",
@@ -3345,13 +3319,13 @@
         "cli-table3": "0.6.5",
         "commander": "4.1.1",
         "fork-ts-checker-webpack-plugin": "9.1.0",
-        "glob": "12.0.0",
+        "glob": "13.0.6",
         "node-emoji": "1.11.0",
         "ora": "5.4.1",
         "tsconfig-paths": "4.2.0",
         "tsconfig-paths-webpack-plugin": "4.2.0",
         "typescript": "5.9.3",
-        "webpack": "5.100.2",
+        "webpack": "5.105.4",
         "webpack-node-externals": "3.0.0"
       },
       "bin": {
@@ -3373,6 +3347,29 @@
         }
       }
     },
+    "node_modules/@nestjs/cli/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@nestjs/cli/node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3384,40 +3381,34 @@
       }
     },
     "node_modules/@nestjs/cli/node_modules/glob": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
-      "integrity": "sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@nestjs/cli/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3438,14 +3429,14 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.2.tgz",
-      "integrity": "sha512-cHh4OPH44PjaHM93D1jgE1HO/B7XTZVRDxy/cPuGgyMEA4p2zXO+qqcOgTMC5FYcp7dX9jLeCjXAU0ToFAnODw==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.17.tgz",
+      "integrity": "sha512-hLODw5Abp8OQgA+mUO4tHou4krKgDtUcM9j5Ihxncst9XeyxYBTt2bwZm4e4EQr5E352S4Fyy6V3iFx9ggxKAg==",
       "license": "MIT",
       "dependencies": {
-        "file-type": "21.0.0",
+        "file-type": "21.3.2",
         "iterare": "1.2.1",
-        "load-esm": "1.0.2",
+        "load-esm": "1.0.3",
         "tslib": "2.8.1",
         "uid": "2.0.2"
       },
@@ -3484,16 +3475,16 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.2.tgz",
-      "integrity": "sha512-QRuyxwu0BjNfmmmunsw1ylX7RSyfDQHt+xD+tKncdtgiMOOzAu+LA1gB4WoZnw4frQkk+qZbhEbM61cIjOxD3w==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.17.tgz",
+      "integrity": "sha512-lD5mAYekTTurF3vDaa8C2OKPnjiz4tsfxIc5XlcSUzOhkwWf6Ay3HKvt6FmvuWQam6uIIHX52Clg+e6tAvf/cg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "path-to-regexp": "8.2.0",
+        "path-to-regexp": "8.3.0",
         "tslib": "2.8.1",
         "uid": "2.0.2"
       },
@@ -3583,9 +3574,9 @@
       }
     },
     "node_modules/@nestjs/microservices": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.2.tgz",
-      "integrity": "sha512-1mhbTZ0rP/QogXN9vGTncmbAFdohfmLOFbxIJZB7QRUUAMoRD3yc7ZqkHPKADz6g6Kgn5B8gzKPkhslwU+gOjw==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-11.1.17.tgz",
+      "integrity": "sha512-rubBPEEXS9PwA3LwdNN/ytjEUmON+d8+4fbiUCIFGW8i+rR/g36vrpwuvoAzcGpxlu45/TpZPfHTb0nJciG9Yw==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
@@ -3663,15 +3654,15 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.5.tgz",
-      "integrity": "sha512-OsoiUBY9Shs5IG3uvDIt9/IDfY5OlvWBESuB/K4Eun8xILw1EK5d5qMfC3d2sIJ+kA3l+kBR1d/RuzH7VprLIg==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.17.tgz",
+      "integrity": "sha512-mAf4eOsSBsTOn/VbrUO1gsjW6dVh91qqXPMXun4dN8SnNjf7PTQagM9o8d6ab8ZBpNe6UdZftdrZoDetU+n4Qg==",
       "license": "MIT",
       "dependencies": {
-        "cors": "2.8.5",
-        "express": "5.1.0",
-        "multer": "2.0.2",
-        "path-to-regexp": "8.2.0",
+        "cors": "2.8.6",
+        "express": "5.2.1",
+        "multer": "2.1.1",
+        "path-to-regexp": "8.3.0",
         "tslib": "2.8.1"
       },
       "funding": {
@@ -3684,12 +3675,12 @@
       }
     },
     "node_modules/@nestjs/platform-socket.io": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.2.tgz",
-      "integrity": "sha512-IkeDPRRddY0In6lE+5H/DJodtF5cEx+ga+GWehs4Il5Y3kK7MVR2/WgUABAhyRsbJYOhIhZD7Dai0V2t9ref1Q==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.17.tgz",
+      "integrity": "sha512-BSOAsENdmTtsnDL0hb4takbWzPy9WoPybjlM57ab3/rQgm0biMFYUupH2uzmCjmmIXJL/EFbAWznVl8xw2Sa6Q==",
       "license": "MIT",
       "dependencies": {
-        "socket.io": "4.8.1",
+        "socket.io": "4.8.3",
         "tslib": "2.8.1"
       },
       "funding": {
@@ -3716,15 +3707,15 @@
       }
     },
     "node_modules/@nestjs/schematics": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.5.tgz",
-      "integrity": "sha512-T50SCNyqCZ/fDssaOD7meBKLZ87ebRLaJqZTJPvJKjlib1VYhMOCwXYsr7bjMPmuPgiQHOwvppz77xN/m6GM7A==",
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.10.tgz",
+      "integrity": "sha512-q9lr0wGwgBHLarD4uno3XiW4JX60WPlg2VTgbqPHl/6bT4u1IEEzj+q9Tad3bVnqL5mlDF3vrZ2tj+x13CJpmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.6",
-        "@angular-devkit/schematics": "19.2.6",
-        "comment-json": "4.2.5",
+        "@angular-devkit/core": "19.2.23",
+        "@angular-devkit/schematics": "19.2.23",
+        "comment-json": "4.6.2",
         "jsonc-parser": "3.3.1",
         "pluralize": "8.0.0"
       },
@@ -3733,16 +3724,16 @@
       }
     },
     "node_modules/@nestjs/schematics/node_modules/@angular-devkit/core": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.6.tgz",
-      "integrity": "sha512-WFgiYhrDMq83UNaGRAneIM7CYYdBozD+yYA9BjoU8AgBLKtrvn6S8ZcjKAk5heoHtY/u8pEb0mwDTz9gxFmJZQ==",
+      "version": "19.2.23",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-19.2.23.tgz",
+      "integrity": "sha512-RazHPQkUEsNU/OZ75w9UeHxGFMthRiuAW2B/uA7eXExBj/1meHrrBfoCA56ujW2GUxVjRtSrMjylKh4R4meiYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "8.17.1",
+        "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.2",
+        "picomatch": "4.0.4",
         "rxjs": "7.8.1",
         "source-map": "0.7.4"
       },
@@ -3761,13 +3752,13 @@
       }
     },
     "node_modules/@nestjs/schematics/node_modules/@angular-devkit/schematics": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.6.tgz",
-      "integrity": "sha512-YTAxNnT++5eflx19OUHmOWu597/TbTel+QARiZCv1xQw99+X8DCKKOUXtqBRd53CAHlREDI33Rn/JLY3NYgMLQ==",
+      "version": "19.2.23",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-19.2.23.tgz",
+      "integrity": "sha512-Jzs7YM4X6azmHU7Mw5tQSPMuvaqYS8SLnZOJbtiXCy1JyuW9bm/WBBecNHMiuZ8LHXKhvQ6AVX1tKrzF6uiDmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "19.2.6",
+        "@angular-devkit/core": "19.2.23",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "5.4.1",
@@ -3780,9 +3771,9 @@
       }
     },
     "node_modules/@nestjs/schematics/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3814,15 +3805,15 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.2.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.5.tgz",
-      "integrity": "sha512-wCykbEybMqiYcvkyzPW4SbXKcwra9AGdajm0MvFgKR3W+gd1hfeKlo67g/s9QCRc/mqUU4KOE5Qtk7asMeFuiA==",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
+      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
         "@nestjs/mapped-types": "2.1.0",
         "js-yaml": "4.1.1",
-        "lodash": "4.17.21",
+        "lodash": "4.17.23",
         "path-to-regexp": "8.3.0",
         "swagger-ui-dist": "5.31.0"
       },
@@ -3846,20 +3837,10 @@
         }
       }
     },
-    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@nestjs/testing": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.2.tgz",
-      "integrity": "sha512-BQxVKUVW6gzEbbHAvmg5RgcP3s++pRgTCmsgaDF/DtcLRUeKi8SjAdqzLm14xbkMeibxOf3fNqM2iwqUKj8ffw==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.17.tgz",
+      "integrity": "sha512-lNffw+z+2USewmw4W0tsK+Rq94A2N4PiHbcqoRUu5y8fnqxQeIWGHhjo5BFCqj7eivqJBhT7WdRydxVq4rAHzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3898,9 +3879,9 @@
       }
     },
     "node_modules/@nestjs/websockets": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.2.tgz",
-      "integrity": "sha512-Ywl7u0C3+qnKIrk0mD3jHWnowO+GScFT1FeP6cNgarA0ujHEfusph9IIbnUJiEiusfnKVpK9fYMGZRSDwnRGPQ==",
+      "version": "11.1.17",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.17.tgz",
+      "integrity": "sha512-YbwQ0QfVj0lxkKQhdIIgk14ZSVWDqGk1J8nNSN6SLjf36sVv58Ma5ro+dtQua8wj3l2Ub7JJCVFixEhKtYc/rQ==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
@@ -4170,13 +4151,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@sec-ant/readable-stream": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
@@ -4230,23 +4204,10 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
-      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.0.tgz",
-      "integrity": "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4256,12 +4217,12 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.1.tgz",
-      "integrity": "sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4269,16 +4230,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
-      "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+      "integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4286,20 +4247,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.4.tgz",
-      "integrity": "sha512-o5tMqPZILBvvROfC8vC+dSVnWJl9a0u9ax1i1+Bq8515eYjUJqqk5XjjEsDLoeL5dSqGSh6WGdVx1eJ1E/Nwhw==",
+      "version": "3.23.13",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.13.tgz",
+      "integrity": "sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4307,15 +4268,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
-      "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+      "integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4323,14 +4284,14 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.5.tgz",
-      "integrity": "sha512-Ogt4Zi9hEbIP17oQMd68qYOHUzmH47UkK7q7Gl55iIm9oKt27MUGrC5JfpMroeHjdkOliOA4Qt3NQ1xMq/nrlA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4338,13 +4299,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.5.tgz",
-      "integrity": "sha512-HohfmCQZjppVnKX2PnXlf47CW3j92Ki6T/vkAT2DhBR47e89pen3s4fIa7otGTtrVxmj7q+IhH0RnC5kpR8wtw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4352,12 +4313,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.5.tgz",
-      "integrity": "sha512-ibjQjM7wEXtECiT6my1xfiMH9IcEczMOS6xiCQXoUIYSj5b1CpBbJ3VYbdwDy8Vcg5JHN7eFpOCGk8nyZAltNQ==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4365,13 +4326,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.5.tgz",
-      "integrity": "sha512-+elOuaYx6F2H6x1/5BQP5ugv12nfJl66GhxON8+dWVUEDJ9jah/A0tayVdkLRP0AeSac0inYkDz5qBFKfVp2Gg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4379,13 +4340,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.5.tgz",
-      "integrity": "sha512-G9WSqbST45bmIFaeNuP/EnC19Rhp54CcVdX9PDL1zyEB514WsDVXhlyihKlGXnRycmHNmVv88Bvvt4EYxWef/Q==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4393,15 +4354,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
-      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+      "version": "5.3.15",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+      "integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/querystring-builder": "^4.2.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4409,14 +4370,14 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.6.tgz",
-      "integrity": "sha512-8P//tA8DVPk+3XURk2rwcKgYwFvwGwmJH/wJqQiSKwXZtf/LiZK+hbUZmPj/9KzM+OVSwe4o85KTp5x9DUZTjw==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.13.tgz",
+      "integrity": "sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^5.2.0",
-        "@smithy/chunked-blob-reader-native": "^4.2.1",
-        "@smithy/types": "^4.9.0",
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4424,14 +4385,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
-      "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+      "integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4439,13 +4400,13 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.5.tgz",
-      "integrity": "sha512-6+do24VnEyvWcGdHXomlpd0m8bfZePpUKBy7m311n+JuRwug8J4dCanJdTymx//8mi0nlkflZBvJe+dEO/O12Q==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.12.tgz",
+      "integrity": "sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4453,12 +4414,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
-      "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+      "integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4466,9 +4427,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4478,13 +4439,13 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.5.tgz",
-      "integrity": "sha512-Bt6jpSTMWfjCtC0s79gZ/WZ1w90grfmopVOWqkI2ovhjpD5Q2XRXuecIPB9689L2+cCySMbaXDhBPU56FKNDNg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.12.tgz",
+      "integrity": "sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4492,13 +4453,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
-      "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+      "integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4506,18 +4467,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.11.tgz",
-      "integrity": "sha512-eJXq9VJzEer1W7EQh3HY2PDJdEcEUnv6sKuNt4eVjyeNWcQFS4KmnY+CKkYOIR6tSqarn6bjjCqg1UB+8UJiPQ==",
+      "version": "4.4.28",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.28.tgz",
+      "integrity": "sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.4",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-serde": "^4.2.16",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
+        "@smithy/util-middleware": "^4.2.12",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4525,19 +4486,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.11.tgz",
-      "integrity": "sha512-EL5OQHvFOKneJVRgzRW4lU7yidSwp/vRJOe542bHgExN3KNThr1rlg0iE4k4SnA+ohC+qlUxoK+smKeAYPzfAQ==",
+      "version": "4.4.46",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.46.tgz",
+      "integrity": "sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/service-error-classification": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.7",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.13",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4545,13 +4506,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
-      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.16.tgz",
+      "integrity": "sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/core": "^3.23.13",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4559,12 +4521,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
-      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+      "integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4572,14 +4534,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
-      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+      "integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/shared-ini-file-loader": "^4.4.7",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4587,15 +4549,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
-      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.1.tgz",
+      "integrity": "sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/querystring-builder": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/querystring-builder": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4603,12 +4564,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
-      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+      "integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4616,12 +4577,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+      "integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4629,13 +4590,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
-      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+      "integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4643,12 +4604,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
-      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+      "integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4656,24 +4617,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
-      "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+      "integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0"
+        "@smithy/types": "^4.13.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
-      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+      "integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4681,18 +4642,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
-      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+      "version": "5.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+      "integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4700,17 +4661,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.9.7",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.7.tgz",
-      "integrity": "sha512-pskaE4kg0P9xNQWihfqlTMyxyFR3CH6Sr6keHYghgyqqDXzjl2QJg5lAzuVe/LzZiOzcbcVtxKYi1/fZPt/3DA==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.8.tgz",
+      "integrity": "sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.4",
-        "@smithy/middleware-endpoint": "^4.3.11",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-stream": "^4.5.6",
+        "@smithy/core": "^3.23.13",
+        "@smithy/middleware-endpoint": "^4.4.28",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-stream": "^4.5.21",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4718,9 +4679,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
-      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4730,13 +4691,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
-      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+      "integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/querystring-parser": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4744,13 +4705,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4758,9 +4719,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4770,9 +4731,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
-      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4782,12 +4743,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4795,9 +4756,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4807,14 +4768,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.10.tgz",
-      "integrity": "sha512-3iA3JVO1VLrP21FsZZpMCeF93aqP3uIOMvymAT3qHIJz2YlgDeRvNUspFwCNqd/j3qqILQJGtsVQnJZICh/9YA==",
+      "version": "4.3.44",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.44.tgz",
+      "integrity": "sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.7",
-        "@smithy/types": "^4.9.0",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4822,17 +4783,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.13.tgz",
-      "integrity": "sha512-PTc6IpnpSGASuzZAgyUtaVfOFpU0jBD2mcGwrgDuHf7PlFgt5TIPxCYBDbFQs06jxgeV3kd/d/sok1pzV0nJRg==",
+      "version": "4.2.48",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.48.tgz",
+      "integrity": "sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.7",
-        "@smithy/types": "^4.9.0",
+        "@smithy/config-resolver": "^4.4.13",
+        "@smithy/credential-provider-imds": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/property-provider": "^4.2.12",
+        "@smithy/smithy-client": "^4.12.8",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4840,13 +4801,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
-      "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+      "integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4854,9 +4815,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4866,12 +4827,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
-      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+      "integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4879,13 +4840,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
-      "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.13.tgz",
+      "integrity": "sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/service-error-classification": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4893,18 +4854,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
-      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+      "version": "4.5.21",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.21.tgz",
+      "integrity": "sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/node-http-handler": "^4.5.1",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4912,9 +4873,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4924,12 +4885,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4937,13 +4898,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.5.tgz",
-      "integrity": "sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.14.tgz",
+      "integrity": "sha512-2zqq5o/oizvMaFUlNiTyZ7dbgYv1a893aGut2uaxtbzTx/VYYnRxWzDHuD/ftgcw94ffenua+ZNLrbqwUYE+Bg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4951,9 +4911,9 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5010,9 +4970,9 @@
       }
     },
     "node_modules/@swc/cli/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5030,13 +4990,13 @@
       }
     },
     "node_modules/@swc/cli/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5285,14 +5245,13 @@
       }
     },
     "node_modules/@tokenizer/inflate": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
-      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
-        "fflate": "^0.8.2",
-        "token-types": "^6.0.0"
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
       },
       "engines": {
         "node": ">=18"
@@ -5531,9 +5490,9 @@
       }
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -6005,9 +5964,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6015,13 +5974,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6234,29 +6193,48 @@
       }
     },
     "node_modules/@xhmikosr/archive-type": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@xhmikosr/archive-type/-/archive-type-7.0.0.tgz",
-      "integrity": "sha512-sIm84ZneCOJuiy3PpWR5bxkx3HaNt1pqaN+vncUBZIlPZCq8ASZH+hBVdu5H8znR7qYC6sKwx+ie2Q7qztJTxA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/archive-type/-/archive-type-7.1.0.tgz",
+      "integrity": "sha512-xZEpnGplg1sNPyEgFh0zbHxqlw5dtYg6viplmWSxUj12+QjU9SKu3U/2G73a15pEjLaOqTefNSZ1fOPUOT4Xgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "file-type": "^19.0.0"
+        "file-type": "^20.5.0"
       },
       "engines": {
-        "node": "^14.14.0 || >=16.0.0"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@xhmikosr/archive-type/node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@xhmikosr/archive-type/node_modules/file-type": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+      "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-stream": "^9.0.1",
-        "strtok3": "^9.0.1",
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
         "token-types": "^6.0.0",
-        "uint8array-extras": "^1.3.0"
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
         "node": ">=18"
@@ -6265,72 +6243,10 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/@xhmikosr/archive-type/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/archive-type/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/archive-type/node_modules/peek-readable": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
-      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@xhmikosr/archive-type/node_modules/strtok3": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
-      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.3.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/@xhmikosr/bin-check": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@xhmikosr/bin-check/-/bin-check-7.0.3.tgz",
-      "integrity": "sha512-4UnCLCs8DB+itHJVkqFp9Zjg+w/205/J2j2wNBsCEAm/BuBmtua2hhUOdAMQE47b1c7P9Xmddj0p+X1XVsfHsA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/bin-check/-/bin-check-7.1.0.tgz",
+      "integrity": "sha512-y1O95J4mnl+6MpVmKfMYXec17hMEwE/yeCglFNdx+QvLLtP0yN4rSYcbkXnth+lElBuKKek2NbvOfOGPpUXCvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6342,14 +6258,14 @@
       }
     },
     "node_modules/@xhmikosr/bin-wrapper": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/@xhmikosr/bin-wrapper/-/bin-wrapper-13.0.5.tgz",
-      "integrity": "sha512-DT2SAuHDeOw0G5bs7wZbQTbf4hd8pJ14tO0i4cWhRkIJfgRdKmMfkDilpaJ8uZyPA0NVRwasCNAmMJcWA67osw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/bin-wrapper/-/bin-wrapper-13.2.0.tgz",
+      "integrity": "sha512-t9U9X0sDPRGDk5TGx4dv5xiOvniVJpXnfTuynVKwHgtib95NYEw4MkZdJqhoSiz820D9m0o6PCqOPMXz0N9fIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@xhmikosr/bin-check": "^7.0.3",
-        "@xhmikosr/downloader": "^15.0.1",
+        "@xhmikosr/bin-check": "^7.1.0",
+        "@xhmikosr/downloader": "^15.2.0",
         "@xhmikosr/os-filter-obj": "^3.0.0",
         "bin-version-check": "^5.1.0"
       },
@@ -6358,18 +6274,17 @@
       }
     },
     "node_modules/@xhmikosr/decompress": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress/-/decompress-10.0.1.tgz",
-      "integrity": "sha512-6uHnEEt5jv9ro0CDzqWlFgPycdE+H+kbJnwyxgZregIMLQ7unQSCNVsYG255FoqU8cP46DyggI7F7LohzEl8Ag==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress/-/decompress-10.2.0.tgz",
+      "integrity": "sha512-MmDBvu0+GmADyQWHolcZuIWffgfnuTo4xpr2I/Qw5Ox0gt+e1Be7oYqJM4te5ylL6mzlcoicnHVDvP27zft8tg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@xhmikosr/decompress-tar": "^8.0.1",
-        "@xhmikosr/decompress-tarbz2": "^8.0.1",
-        "@xhmikosr/decompress-targz": "^8.0.1",
-        "@xhmikosr/decompress-unzip": "^7.0.0",
+        "@xhmikosr/decompress-tar": "^8.1.0",
+        "@xhmikosr/decompress-tarbz2": "^8.1.0",
+        "@xhmikosr/decompress-targz": "^8.1.0",
+        "@xhmikosr/decompress-unzip": "^7.1.0",
         "graceful-fs": "^4.2.11",
-        "make-dir": "^4.0.0",
         "strip-dirs": "^3.0.0"
       },
       "engines": {
@@ -6377,13 +6292,13 @@
       }
     },
     "node_modules/@xhmikosr/decompress-tar": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tar/-/decompress-tar-8.0.1.tgz",
-      "integrity": "sha512-dpEgs0cQKJ2xpIaGSO0hrzz3Kt8TQHYdizHsgDtLorWajuHJqxzot9Hbi0huRxJuAGG2qiHSQkwyvHHQtlE+fg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tar/-/decompress-tar-8.1.0.tgz",
+      "integrity": "sha512-m0q8x6lwxenh1CrsTby0Jrjq4vzW/QU1OLhTHMQLEdHpmjR1lgahGz++seZI0bXF3XcZw3U3xHfqZSz+JPP2Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "file-type": "^19.0.0",
+        "file-type": "^20.5.0",
         "is-stream": "^2.0.1",
         "tar-stream": "^3.1.7"
       },
@@ -6391,17 +6306,36 @@
         "node": ">=18"
       }
     },
-    "node_modules/@xhmikosr/decompress-tar/node_modules/file-type": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+    "node_modules/@xhmikosr/decompress-tar/node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-stream": "^9.0.1",
-        "strtok3": "^9.0.1",
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@xhmikosr/decompress-tar/node_modules/file-type": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+      "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
         "token-types": "^6.0.0",
-        "uint8array-extras": "^1.3.0"
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
         "node": ">=18"
@@ -6410,77 +6344,15 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/@xhmikosr/decompress-tar/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-tar/node_modules/get-stream/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-tar/node_modules/peek-readable": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
-      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-tar/node_modules/strtok3": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
-      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.3.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/@xhmikosr/decompress-tarbz2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tarbz2/-/decompress-tarbz2-8.0.2.tgz",
-      "integrity": "sha512-p5A2r/AVynTQSsF34Pig6olt9CvRj6J5ikIhzUd3b57pUXyFDGtmBstcw+xXza0QFUh93zJsmY3zGeNDlR2AQQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-tarbz2/-/decompress-tarbz2-8.1.0.tgz",
+      "integrity": "sha512-aCLfr3A/FWZnOu5eqnJfme1Z1aumai/WRw55pCvBP+hCGnTFrcpsuiaVN5zmWTR53a8umxncY2JuYsD42QQEbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xhmikosr/decompress-tar": "^8.0.1",
-        "file-type": "^19.6.0",
+        "file-type": "^20.5.0",
         "is-stream": "^2.0.1",
         "seek-bzip": "^2.0.0",
         "unbzip2-stream": "^1.4.3"
@@ -6489,17 +6361,36 @@
         "node": ">=18"
       }
     },
-    "node_modules/@xhmikosr/decompress-tarbz2/node_modules/file-type": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+    "node_modules/@xhmikosr/decompress-tarbz2/node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-stream": "^9.0.1",
-        "strtok3": "^9.0.1",
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@xhmikosr/decompress-tarbz2/node_modules/file-type": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+      "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
         "token-types": "^6.0.0",
-        "uint8array-extras": "^1.3.0"
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
         "node": ">=18"
@@ -6508,94 +6399,51 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/@xhmikosr/decompress-tarbz2/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-tarbz2/node_modules/get-stream/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-tarbz2/node_modules/peek-readable": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
-      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-tarbz2/node_modules/strtok3": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
-      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.3.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/@xhmikosr/decompress-targz": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-targz/-/decompress-targz-8.0.1.tgz",
-      "integrity": "sha512-mvy5AIDIZjQ2IagMI/wvauEiSNHhu/g65qpdM4EVoYHUJBAmkQWqcPJa8Xzi1aKVTmOA5xLJeDk7dqSjlHq8Mg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-targz/-/decompress-targz-8.1.0.tgz",
+      "integrity": "sha512-fhClQ2wTmzxzdz2OhSQNo9ExefrAagw93qaG1YggoIz/QpI7atSRa7eOHv4JZkpHWs91XNn8Hry3CwUlBQhfPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xhmikosr/decompress-tar": "^8.0.1",
-        "file-type": "^19.0.0",
+        "file-type": "^20.5.0",
         "is-stream": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@xhmikosr/decompress-targz/node_modules/file-type": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+    "node_modules/@xhmikosr/decompress-targz/node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-stream": "^9.0.1",
-        "strtok3": "^9.0.1",
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@xhmikosr/decompress-targz/node_modules/file-type": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+      "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
         "token-types": "^6.0.0",
-        "uint8array-extras": "^1.3.0"
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
         "node": ">=18"
@@ -6604,76 +6452,14 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/@xhmikosr/decompress-targz/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-targz/node_modules/get-stream/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-targz/node_modules/peek-readable": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
-      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-targz/node_modules/strtok3": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
-      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.3.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/@xhmikosr/decompress-unzip": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-7.0.0.tgz",
-      "integrity": "sha512-GQMpzIpWTsNr6UZbISawsGI0hJ4KA/mz5nFq+cEoPs12UybAqZWKbyIaZZyLbJebKl5FkLpsGBkrplJdjvUoSQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/decompress-unzip/-/decompress-unzip-7.1.0.tgz",
+      "integrity": "sha512-oqTYAcObqTlg8owulxFTqiaJkfv2SHsxxxz9Wg4krJAHVzGWlZsU8tAB30R6ow+aHrfv4Kub6WQ8u04NWVPUpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "file-type": "^19.0.0",
+        "file-type": "^20.5.0",
         "get-stream": "^6.0.1",
         "yauzl": "^3.1.2"
       },
@@ -6681,17 +6467,36 @@
         "node": ">=18"
       }
     },
-    "node_modules/@xhmikosr/decompress-unzip/node_modules/file-type": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+    "node_modules/@xhmikosr/decompress-unzip/node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-stream": "^9.0.1",
-        "strtok3": "^9.0.1",
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@xhmikosr/decompress-unzip/node_modules/file-type": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+      "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
         "token-types": "^6.0.0",
-        "uint8array-extras": "^1.3.0"
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
         "node": ">=18"
@@ -6700,81 +6505,19 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/@xhmikosr/decompress-unzip/node_modules/file-type/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-unzip/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-unzip/node_modules/peek-readable": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
-      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@xhmikosr/decompress-unzip/node_modules/strtok3": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
-      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.3.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/@xhmikosr/downloader": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/@xhmikosr/downloader/-/downloader-15.0.1.tgz",
-      "integrity": "sha512-fiuFHf3Dt6pkX8HQrVBsK0uXtkgkVlhrZEh8b7VgoDqFf+zrgFBPyrwCqE/3nDwn3hLeNz+BsrS7q3mu13Lp1g==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@xhmikosr/downloader/-/downloader-15.2.0.tgz",
+      "integrity": "sha512-lAqbig3uRGTt0sHNIM4vUG9HoM+mRl8K28WuYxyXLCUT6pyzl4Y4i0LZ3jMEsCYZ6zjPZbO9XkG91OSTd4si7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@xhmikosr/archive-type": "^7.0.0",
-        "@xhmikosr/decompress": "^10.0.1",
+        "@xhmikosr/archive-type": "^7.1.0",
+        "@xhmikosr/decompress": "^10.2.0",
         "content-disposition": "^0.5.4",
-        "defaults": "^3.0.0",
+        "defaults": "^2.0.2",
         "ext-name": "^5.0.0",
-        "file-type": "^19.0.0",
+        "file-type": "^20.5.0",
         "filenamify": "^6.0.0",
         "get-stream": "^6.0.1",
         "got": "^13.0.0"
@@ -6783,85 +6526,42 @@
         "node": ">=18"
       }
     },
-    "node_modules/@xhmikosr/downloader/node_modules/file-type": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
+    "node_modules/@xhmikosr/downloader/node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-stream": "^9.0.1",
-        "strtok3": "^9.0.1",
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@xhmikosr/downloader/node_modules/file-type": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+      "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
         "token-types": "^6.0.0",
-        "uint8array-extras": "^1.3.0"
+        "uint8array-extras": "^1.4.0"
       },
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/@xhmikosr/downloader/node_modules/file-type/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/downloader/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@xhmikosr/downloader/node_modules/peek-readable": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.4.2.tgz",
-      "integrity": "sha512-peBp3qZyuS6cNIJ2akRNG1uo1WJ1d0wTxg/fxMdZ0BqCVhx242bSFHM9eNqflfJVS9SsgkzgT/1UgnsurBOTMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@xhmikosr/downloader/node_modules/strtok3": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-9.1.1.tgz",
-      "integrity": "sha512-FhwotcEqjr241ZbjFzjlIYg6c5/L/s4yBGWSMvJ9UoExiSqL+FnFA/CaeZx17WGaZMS/4SOZp8wH18jSS4R4lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.3.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@xhmikosr/os-filter-obj": {
@@ -6923,9 +6623,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -7011,9 +6711,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7046,9 +6746,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7152,19 +6852,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/app-root-path": {
@@ -7295,14 +6982,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -7481,6 +7168,19 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
+      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bcrypt": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
@@ -7590,10 +7290,104 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/bowser": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
-      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -7620,9 +7414,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -7640,10 +7434,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7982,9 +7777,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001720",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
-      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
+      "version": "1.0.30001784",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
+      "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
       "dev": true,
       "funding": [
         {
@@ -8312,17 +8107,14 @@
       }
     },
     "node_modules/comment-json": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.5.tgz",
-      "integrity": "sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.6.2.tgz",
+      "integrity": "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
-        "core-util-is": "^1.0.3",
-        "esprima": "^4.0.1",
-        "has-own-prop": "^2.0.0",
-        "repeat-string": "^1.6.1"
+        "esprima": "^4.0.1"
       },
       "engines": {
         "node": ">= 6"
@@ -8466,17 +8258,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -8484,6 +8269,10 @@
       },
       "engines": {
         "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cosmiconfig": {
@@ -8662,13 +8451,13 @@
       }
     },
     "node_modules/defaults": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-3.0.0.tgz",
-      "integrity": "sha512-RsqXDEAALjfRTro+IFNKpcPCt0/Cy2FqHSIlnomiJp9YGadpQnrtbRpSgN2+np21qHcIKiva4fiOQGjS9/qR/A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-2.0.2.tgz",
+      "integrity": "sha512-cuIw0PImdp76AOfgkjbW4VhQODRmNNcKR73vdCH5cLd/ifj7aamfoXvYgfGkEAjNJZ3ozMIy9Gu2LutUkGEPbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8919,9 +8708,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.161",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.161.tgz",
-      "integrity": "sha512-hwtetwfKNZo/UlwHIVBlKZVdy7o8bIZxxKs0Mv/ROPiQQQmDgdm5a+KvKtBsxM8ZjFzTaCeLoodZ8jiBE3o9rA==",
+      "version": "1.5.330",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.330.tgz",
+      "integrity": "sha512-jFNydB5kFtYUobh4IkWUnXeyDbjf/r9gcUEXe1xcrcUxIGfTdzPXA+ld6zBRbwvgIGVzDll/LTIiDztEtckSnA==",
       "dev": true,
       "license": "ISC"
     },
@@ -9093,14 +8882,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -9166,9 +8955,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9545,18 +9334,19 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -9626,125 +9416,17 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express/node_modules/body-parser/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/body-parser/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "license": "MIT",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/express/node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
+      "engines": {
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/express/node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "~3.1.2",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ext-list": {
@@ -9846,9 +9528,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
       "funding": [
         {
@@ -9862,10 +9544,10 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -9874,7 +9556,24 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -9904,6 +9603,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -9920,14 +9620,14 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.0.0.tgz",
-      "integrity": "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==",
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
       "license": "MIT",
       "dependencies": {
-        "@tokenizer/inflate": "^0.2.7",
-        "strtok3": "^10.2.2",
-        "token-types": "^6.0.0",
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
         "uint8array-extras": "^1.4.0"
       },
       "engines": {
@@ -9955,9 +9655,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9965,9 +9665,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10020,9 +9720,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -10033,7 +9733,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-cache-dir": {
@@ -10138,16 +9842,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -10224,9 +9928,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -10601,17 +10305,40 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10722,16 +10449,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/has-own-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
-      "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12011,19 +11728,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-validate": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
@@ -12408,9 +12112,9 @@
       "license": "MIT"
     },
     "node_modules/load-esm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.2.tgz",
-      "integrity": "sha512-nVAvWk/jeyrWyXEAs84mpQCYccxRqgKY4OznLuJhJCa0XsPSfdOIr2zvBZEj3IHEHbX97jjscKRRV539bW0Gpw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+      "integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
       "funding": [
         {
           "type": "github",
@@ -12427,13 +12131,17 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -12806,19 +12514,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -12842,15 +12537,19 @@
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -12877,9 +12576,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -12892,16 +12591,17 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -13128,18 +12828,6 @@
       "license": "ISC",
       "optional": true
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -13363,21 +13051,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
-      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
         "concat-stream": "^2.0.0",
-        "mkdirp": "^0.5.6",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.18",
-        "xtend": "^4.0.2"
+        "type-is": "^1.6.18"
       },
       "engines": {
         "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/multer/node_modules/media-typer": {
@@ -13697,9 +13386,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13789,19 +13478,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/nodemon/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/nodemon/node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -13854,9 +13530,9 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-      "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14230,6 +13906,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -14256,9 +13947,9 @@
       "license": "MIT"
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -14266,7 +13957,7 @@
         "minipass": "^7.1.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -14283,12 +13974,13 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -14313,19 +14005,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://ko-fi.com/killymxi"
-      }
-    },
-    "node_modules/peek-readable": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
-      "integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/pend": {
@@ -14432,9 +14111,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14779,10 +14458,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -14829,9 +14511,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -14886,16 +14568,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -14903,6 +14575,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rc": {
@@ -15026,16 +14725,6 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -15429,41 +15118,35 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -15473,6 +15156,10 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-blocking": {
@@ -15724,15 +15411,15 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
-      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "cors": "~2.8.5",
-        "debug": "~4.3.2",
+        "debug": "~4.4.1",
         "engine.io": "~6.6.0",
         "socket.io-adapter": "~2.5.2",
         "socket.io-parser": "~4.2.4"
@@ -15801,33 +15488,16 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
+        "debug": "~4.4.1"
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/socket.io-parser/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/socket.io/node_modules/accepts": {
@@ -15841,23 +15511,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/socket.io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/socket.io/node_modules/mime-db": {
@@ -16346,9 +15999,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "funding": [
         {
           "type": "github",
@@ -16358,13 +16011,12 @@
       "license": "MIT"
     },
     "node_modules/strtok3": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.2.2.tgz",
-      "integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
       "license": "MIT",
       "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^7.0.0"
+        "@tokenizer/token": "^0.3.0"
       },
       "engines": {
         "node": ">=18"
@@ -16471,19 +16123,23 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -16576,14 +16232,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.40.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.40.0.tgz",
-      "integrity": "sha512-cfeKl/jjwSR5ar7d0FGmave9hFGJT8obyo0z+CrQOylLDbk7X81nPU6vq9VORa5jU30SkDnT2FXjLbR8HLP+xA==",
+      "version": "5.46.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -16595,16 +16251,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {
@@ -16630,9 +16285,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16700,9 +16355,9 @@
       "license": "MIT"
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16840,11 +16495,12 @@
       }
     },
     "node_modules/token-types": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
-      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
       "license": "MIT",
       "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
@@ -17245,9 +16901,9 @@
       }
     },
     "node_modules/typeorm/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -17307,12 +16963,12 @@
       "license": "ISC"
     },
     "node_modules/typeorm/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -17501,9 +17157,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -17620,9 +17276,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17672,9 +17328,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.100.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
-      "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
+      "version": "5.105.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
+      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17684,25 +17340,25 @@
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.20.0",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
+        "loader-runner": "^4.3.1",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.3.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.17",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.4"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -17731,9 +17387,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17741,9 +17397,9 @@
       }
     },
     "node_modules/webpack/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17843,9 +17499,9 @@
       }
     },
     "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18110,9 +17766,9 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,10 @@
     "body-parser": "^1.20.3",
     "diff": "^4.0.4",
     "jws": "^3.2.3",
-    "qs": "^6.14.1"
+    "qs": "^6.14.1",
+    "path-to-regexp": "^8.4.1",
+    "picomatch": "^4.0.4",
+    "yauzl": "^3.2.1"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/src/context/leads/application/dtos/crm-config.dto.ts
+++ b/src/context/leads/application/dtos/crm-config.dto.ts
@@ -100,22 +100,20 @@ export class LeadcarsConfigDto {
   sedeId?: number;
 
   @ApiPropertyOptional({
-    description: 'ID de la campaña (opcional)',
-    example: 789,
-  })
-  @IsOptional()
-  @IsNumber()
-  @Min(1)
-  campanaId?: number;
-
-  @ApiPropertyOptional({
-    description: 'Tipo de lead por defecto',
-    example: 'web',
-    default: 'web',
+    description: 'Código de campaña (texto, no numérico)',
+    example: 'WEB-2026',
   })
   @IsOptional()
   @IsString()
-  tipoLeadDefault?: string;
+  campanaCode?: string;
+
+  @ApiProperty({
+    description: 'ID numérico del tipo de lead (de GET /tipos)',
+    example: 7,
+  })
+  @IsNumber()
+  @Min(1)
+  tipoLeadDefault: number;
 }
 
 /**

--- a/src/context/leads/infrastructure/adapters/leadcars/leadcars-api.service.ts
+++ b/src/context/leads/infrastructure/adapters/leadcars/leadcars-api.service.ts
@@ -113,12 +113,13 @@ export class LeadcarsApiService {
   }
 
   /**
-   * Obtiene la lista de campañas disponibles
+   * Obtiene la lista de campañas de un concesionario
    */
   async listCampanas(
+    concesionarioId: number,
     config: LeadcarsConfig,
   ): Promise<Result<LeadcarsListCampanasResponse, DomainError>> {
-    const url = `${this.getBaseUrl(config)}/campanas`;
+    const url = `${this.getBaseUrl(config)}/campanas/${concesionarioId}`;
 
     return this.executeWithRetry<LeadcarsListCampanasResponse>(
       () => this.get<LeadcarsListCampanasResponse>(url, config),

--- a/src/context/leads/infrastructure/adapters/leadcars/leadcars-api.service.ts
+++ b/src/context/leads/infrastructure/adapters/leadcars/leadcars-api.service.ts
@@ -119,6 +119,15 @@ export class LeadcarsApiService {
     concesionarioId: number,
     config: LeadcarsConfig,
   ): Promise<Result<LeadcarsListCampanasResponse, DomainError>> {
+    if (!Number.isInteger(concesionarioId) || concesionarioId <= 0) {
+      return err(
+        new CrmApiError(
+          'leadcars',
+          `concesionarioId inválido: ${concesionarioId}. Debe ser un entero positivo.`,
+        ),
+      );
+    }
+
     const url = `${this.getBaseUrl(config)}/campanas/${concesionarioId}`;
 
     return this.executeWithRetry<LeadcarsListCampanasResponse>(

--- a/src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts
+++ b/src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts
@@ -18,7 +18,6 @@ import { LeadcarsApiService } from './leadcars-api.service';
 import {
   LeadcarsConfig,
   LeadcarsCreateLeadRequest,
-  LeadcarsTipoLead,
   LeadcarsChatMessage,
 } from './leadcars.types';
 
@@ -217,24 +216,13 @@ export class LeadcarsCrmSyncAdapter implements ICrmSyncService {
       errors.push('useSandbox es obligatorio');
     }
 
-    if (!leadcarsConfig.tipoLeadDefault) {
-      errors.push('tipoLeadDefault es obligatorio');
-    } else {
-      const validTipos: LeadcarsTipoLead[] = [
-        'COMPRA',
-        'VENTA',
-        'FINANCIACION',
-        'TALLER',
-        'RECAMBIOS',
-        'OTRO',
-      ];
-      if (
-        !validTipos.includes(leadcarsConfig.tipoLeadDefault as LeadcarsTipoLead)
-      ) {
-        errors.push(
-          `tipoLeadDefault debe ser uno de: ${validTipos.join(', ')}`,
-        );
-      }
+    if (
+      typeof leadcarsConfig.tipoLeadDefault !== 'number' ||
+      leadcarsConfig.tipoLeadDefault <= 0
+    ) {
+      errors.push(
+        'tipoLeadDefault es obligatorio y debe ser un número positivo (ID de GET /tipos)',
+      );
     }
 
     return errors;
@@ -252,8 +240,11 @@ export class LeadcarsCrmSyncAdapter implements ICrmSyncService {
       useSandbox: rawConfig.useSandbox as boolean,
       concesionarioId: rawConfig.concesionarioId as number,
       sedeId: rawConfig.sedeId as number | undefined,
-      campanaId: rawConfig.campanaId as number | undefined,
-      tipoLeadDefault: rawConfig.tipoLeadDefault as string,
+      // Compatibilidad: leer campanaCode o campana (antes: campanaId)
+      campanaCode: (rawConfig.campanaCode || rawConfig.campana) as
+        | string
+        | undefined,
+      tipoLeadDefault: rawConfig.tipoLeadDefault as number,
     };
   }
 
@@ -263,12 +254,12 @@ export class LeadcarsCrmSyncAdapter implements ICrmSyncService {
   ): LeadcarsCreateLeadRequest {
     const request: LeadcarsCreateLeadRequest = {
       nombre: contactData.nombre || 'Visitante',
-      concesionario_id: config.concesionarioId,
-      tipo_lead: config.tipoLeadDefault as LeadcarsTipoLead,
-      origen_lead: 'CHAT',
+      concesionario: config.concesionarioId,
+      tipo_lead: config.tipoLeadDefault,
+      comentario: `Lead generado automáticamente desde chat de Guiders (visitor: ${contactData.visitorId})`,
     };
 
-    // Campos opcionales
+    // Campos opcionales de contacto
     if (contactData.apellidos) {
       request.apellidos = contactData.apellidos;
     }
@@ -281,38 +272,27 @@ export class LeadcarsCrmSyncAdapter implements ICrmSyncService {
       request.telefono = contactData.telefono;
     }
 
-    if (contactData.dni) {
-      request.dni = contactData.dni;
-    }
-
+    // Mapear poblacion → provincia (nombre correcto en API v2.4)
     if (contactData.poblacion) {
-      request.poblacion = contactData.poblacion;
+      request.provincia = contactData.poblacion;
     }
 
     if (config.sedeId) {
-      request.sede_id = config.sedeId;
+      request.sede = config.sedeId;
     }
 
-    if (config.campanaId) {
-      request.campana_id = config.campanaId;
+    // campanaCode es texto (antes campanaId era número)
+    if (config.campanaCode) {
+      request.campana = config.campanaCode;
     }
 
-    // Datos adicionales
+    // Campos dinámicos al nivel raíz (no dentro de datos_adicionales)
+    request['guiders_visitor_id'] = contactData.visitorId;
+    request['guiders_company_id'] = contactData.companyId;
+
     if (contactData.additionalData) {
-      request.datos_adicionales = {
-        ...contactData.additionalData,
-        guiders_visitor_id: contactData.visitorId,
-        guiders_company_id: contactData.companyId,
-      };
-    } else {
-      request.datos_adicionales = {
-        guiders_visitor_id: contactData.visitorId,
-        guiders_company_id: contactData.companyId,
-      };
+      Object.assign(request, contactData.additionalData);
     }
-
-    // Añadir observaciones con info de origen
-    request.observaciones = `Lead generado automáticamente desde chat de Guiders (visitor: ${contactData.visitorId})`;
 
     return request;
   }

--- a/src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts
+++ b/src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts
@@ -307,6 +307,7 @@ export class LeadcarsCrmSyncAdapter implements ICrmSyncService {
 
     if (contactData.additionalData) {
       // Filtrar keys que colisionarían con campos conocidos del request
+      // y keys peligrosas para evitar prototype pollution
       const protectedKeys = new Set([
         'nombre',
         'apellidos',
@@ -323,6 +324,9 @@ export class LeadcarsCrmSyncAdapter implements ICrmSyncService {
         'campana',
         'guiders_visitor_id',
         'guiders_company_id',
+        '__proto__',
+        'constructor',
+        'prototype',
       ]);
 
       for (const [key, value] of Object.entries(contactData.additionalData)) {

--- a/src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts
+++ b/src/context/leads/infrastructure/adapters/leadcars/leadcars-crm-sync.adapter.ts
@@ -208,20 +208,33 @@ export class LeadcarsCrmSyncAdapter implements ICrmSyncService {
       errors.push('clienteToken es obligatorio');
     }
 
-    if (typeof leadcarsConfig.concesionarioId !== 'number') {
-      errors.push('concesionarioId es obligatorio y debe ser un número');
+    if (
+      typeof leadcarsConfig.concesionarioId !== 'number' ||
+      leadcarsConfig.concesionarioId <= 0
+    ) {
+      errors.push(
+        'concesionarioId es obligatorio y debe ser un número positivo',
+      );
     }
 
     if (leadcarsConfig.useSandbox === undefined) {
       errors.push('useSandbox es obligatorio');
     }
 
-    if (
-      typeof leadcarsConfig.tipoLeadDefault !== 'number' ||
-      leadcarsConfig.tipoLeadDefault <= 0
+    // Detectar configs legacy donde tipoLeadDefault era string (antes del check de tipo)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rawTipoLead = (leadcarsConfig as any).tipoLeadDefault;
+    if (typeof rawTipoLead === 'string') {
+      errors.push(
+        `tipoLeadDefault tiene valor string "${rawTipoLead}". Debe ser un ID numérico de GET /tipos. Re-configure la integración.`,
+      );
+    } else if (
+      typeof rawTipoLead !== 'number' ||
+      !Number.isInteger(rawTipoLead) ||
+      rawTipoLead <= 0
     ) {
       errors.push(
-        'tipoLeadDefault es obligatorio y debe ser un número positivo (ID de GET /tipos)',
+        'tipoLeadDefault es obligatorio y debe ser un número entero positivo (ID de GET /tipos)',
       );
     }
 
@@ -240,10 +253,12 @@ export class LeadcarsCrmSyncAdapter implements ICrmSyncService {
       useSandbox: rawConfig.useSandbox as boolean,
       concesionarioId: rawConfig.concesionarioId as number,
       sedeId: rawConfig.sedeId as number | undefined,
-      // Compatibilidad: leer campanaCode o campana (antes: campanaId)
-      campanaCode: (rawConfig.campanaCode || rawConfig.campana) as
-        | string
-        | undefined,
+      // Compatibilidad: leer campanaCode, campana, o campanaId (legacy, convertir a string)
+      campanaCode: (rawConfig.campanaCode ||
+        rawConfig.campana ||
+        (rawConfig.campanaId != null
+          ? `${rawConfig.campanaId as number}`
+          : undefined)) as string | undefined,
       tipoLeadDefault: rawConfig.tipoLeadDefault as number,
     };
   }
@@ -291,7 +306,34 @@ export class LeadcarsCrmSyncAdapter implements ICrmSyncService {
     request['guiders_company_id'] = contactData.companyId;
 
     if (contactData.additionalData) {
-      Object.assign(request, contactData.additionalData);
+      // Filtrar keys que colisionarían con campos conocidos del request
+      const protectedKeys = new Set([
+        'nombre',
+        'apellidos',
+        'email',
+        'telefono',
+        'movil',
+        'cp',
+        'provincia',
+        'comentario',
+        'url_origen',
+        'concesionario',
+        'sede',
+        'tipo_lead',
+        'campana',
+        'guiders_visitor_id',
+        'guiders_company_id',
+      ]);
+
+      for (const [key, value] of Object.entries(contactData.additionalData)) {
+        if (!protectedKeys.has(key)) {
+          request[key] = value;
+        } else {
+          this.logger.warn(
+            `additionalData contiene key protegida '${key}', ignorada para evitar sobreescritura`,
+          );
+        }
+      }
     }
 
     return request;

--- a/src/context/leads/infrastructure/adapters/leadcars/leadcars.types.ts
+++ b/src/context/leads/infrastructure/adapters/leadcars/leadcars.types.ts
@@ -1,6 +1,6 @@
 /**
- * Tipos específicos para la integración con LeadCars API v2
- * Documentación: https://api.leadcars.es/api/v2
+ * Tipos específicos para la integración con LeadCars API v2.4
+ * Documentación oficial: docs/leadcar/LeadCars_API_V2_4.pdf
  */
 
 /**
@@ -11,50 +11,41 @@ export interface LeadcarsConfig {
   useSandbox: boolean;
   concesionarioId: number;
   sedeId?: number;
-  campanaId?: number;
-  tipoLeadDefault: string;
+  /** Código de campaña (texto, no numérico). Antes: campanaId (number) */
+  campanaCode?: string;
+  /** ID numérico del tipo de lead obtenido de GET /tipos. Antes: string enum */
+  tipoLeadDefault: number;
 }
 
 /**
- * Tipos de lead soportados por LeadCars
- */
-export type LeadcarsTipoLead =
-  | 'COMPRA'
-  | 'VENTA'
-  | 'FINANCIACION'
-  | 'TALLER'
-  | 'RECAMBIOS'
-  | 'OTRO';
-
-/**
- * Orígenes de lead soportados
- */
-export type LeadcarsOrigenLead =
-  | 'WEB'
-  | 'TELEFONO'
-  | 'PRESENCIAL'
-  | 'EMAIL'
-  | 'REDES_SOCIALES'
-  | 'CHAT'
-  | 'OTRO';
-
-/**
- * Request para crear un lead en LeadCars
+ * Request para crear un lead en LeadCars (API v2.4)
+ * Campos dinámicos se envían al nivel raíz mediante el index signature.
  */
 export interface LeadcarsCreateLeadRequest {
   nombre: string;
   apellidos?: string;
   email?: string;
   telefono?: string;
-  dni?: string;
-  poblacion?: string;
-  concesionario_id: number;
-  sede_id?: number;
-  campana_id?: number;
-  tipo_lead: LeadcarsTipoLead;
-  origen_lead: LeadcarsOrigenLead;
-  observaciones?: string;
-  datos_adicionales?: Record<string, unknown>;
+  /** Teléfono móvil adicional en formato E.164 */
+  movil?: string;
+  /** Código postal */
+  cp?: string;
+  /** Provincia (antes: poblacion) */
+  provincia?: string;
+  /** Comentario/observaciones (antes: observaciones) */
+  comentario?: string;
+  /** URL de origen del lead */
+  url_origen?: string;
+  /** ID del concesionario (antes: concesionario_id) */
+  concesionario: number;
+  /** ID de la sede (antes: sede_id) */
+  sede?: number;
+  /** ID numérico del tipo de lead de GET /tipos (antes: LeadcarsTipoLead string enum) */
+  tipo_lead: number;
+  /** Código de campaña en texto (antes: campana_id number) */
+  campana?: string;
+  /** Campos dinámicos clave:valor al nivel raíz del JSON */
+  [key: string]: unknown;
 }
 
 /**
@@ -246,7 +237,7 @@ export interface LeadcarsListTiposResponse {
 }
 
 /**
- * URLs base de LeadCars
+ * URLs base de LeadCars API v2.4
  */
 export const LEADCARS_API_URLS = {
   production: 'https://api.leadcars.es/api/v2',

--- a/src/context/leads/infrastructure/controllers/leads-admin.controller.ts
+++ b/src/context/leads/infrastructure/controllers/leads-admin.controller.ts
@@ -651,8 +651,14 @@ export class LeadsAdminController {
     const leadcarsConfig = await this.getLeadcarsConfigForCompany(companyId);
     const concesionarioIdNum = parseInt(concesionarioId, 10);
 
-    if (isNaN(concesionarioIdNum)) {
-      throw new BadRequestException('concesionarioId debe ser un número');
+    if (
+      isNaN(concesionarioIdNum) ||
+      !Number.isInteger(concesionarioIdNum) ||
+      concesionarioIdNum <= 0
+    ) {
+      throw new BadRequestException(
+        'concesionarioId debe ser un número entero positivo',
+      );
     }
 
     const result = await this.leadcarsApiService.listSedes(
@@ -704,8 +710,14 @@ export class LeadsAdminController {
     const leadcarsConfig = await this.getLeadcarsConfigForCompany(companyId);
     const concesionarioIdNum = parseInt(concesionarioId, 10);
 
-    if (isNaN(concesionarioIdNum)) {
-      throw new BadRequestException('concesionarioId debe ser un número');
+    if (
+      isNaN(concesionarioIdNum) ||
+      !Number.isInteger(concesionarioIdNum) ||
+      concesionarioIdNum <= 0
+    ) {
+      throw new BadRequestException(
+        'concesionarioId debe ser un número entero positivo',
+      );
     }
 
     // Usar el concesionarioId del parámetro (no el de la config)

--- a/src/context/leads/infrastructure/controllers/leads-admin.controller.ts
+++ b/src/context/leads/infrastructure/controllers/leads-admin.controller.ts
@@ -582,8 +582,10 @@ export class LeadsAdminController {
       useSandbox: (config.config.useSandbox as boolean) ?? false,
       concesionarioId: config.config.concesionarioId as number,
       sedeId: config.config.sedeId as number | undefined,
-      campanaId: config.config.campanaId as number | undefined,
-      tipoLeadDefault: config.config.tipoLeadDefault as string,
+      campanaCode: (config.config.campanaCode || config.config.campana) as
+        | string
+        | undefined,
+      tipoLeadDefault: config.config.tipoLeadDefault as number,
     };
   }
 
@@ -712,7 +714,10 @@ export class LeadsAdminController {
       concesionarioId: concesionarioIdNum,
     };
 
-    const result = await this.leadcarsApiService.listCampanas(configForRequest);
+    const result = await this.leadcarsApiService.listCampanas(
+      concesionarioIdNum,
+      configForRequest,
+    );
     if (result.isErr()) {
       throw new InternalServerErrorException(
         `Error al obtener campañas de LeadCars: ${result.error.message}`,


### PR DESCRIPTION
## Summary

- Alinea `LeadcarsCreateLeadRequest`, `LeadcarsConfig` y el DTO `LeadcarsConfigDto` con la API real de LeadCars v2.4
- Corrige nombres de campos (`concesionario_id` → `concesionario`, `sede_id` → `sede`, `campana_id` → `campana`), tipos (`tipo_lead` ahora es `number`, `campana` es `string`) y estructura (campos dinámicos al nivel raíz en vez de `datos_adicionales`)
- Elimina tipos obsoletos (`LeadcarsTipoLead`, `LeadcarsOrigenLead`) y campos que no existen en la API (`origen_lead`, `dni`, `datos_adicionales`, `observaciones`)
- Actualiza `listCampanas` para recibir `concesionarioId` como parámetro de ruta

## Code Review Patches (segundo commit)

- **Object.assign injection**: Filtrado de keys protegidas en `additionalData` para evitar sobreescritura de campos críticos del request
- **tipoLeadDefault floats**: Validación con `Number.isInteger()` 
- **Legacy detection**: Detección de configs con `tipoLeadDefault` string (legacy) con mensaje descriptivo
- **concesionarioId=0**: Validación `> 0` añadida
- **campanaId fallback**: `extractLeadcarsConfig` ahora lee `campanaCode || campana || campanaId` para compatibilidad con datos existentes
- **DTO actualizado**: `campanaId: number` → `campanaCode: string`, `tipoLeadDefault: string` → `number`

## Validaciones

- 0 errores TypeScript
- 0 errores ESLint
- 6/6 tests unitarios del contexto leads pasan
- 1479/1497 tests totales pasan (sin regresiones)

## Story file

`_bmad-output/implementation-artifacts/4-1-corregir-tipos-y-request-crear-lead.md`

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `leadcars.types.ts` | Tipos del request y config actualizados |
| `leadcars-crm-sync.adapter.ts` | buildCreateLeadRequest, validateConfig, extractLeadcarsConfig |
| `leadcars-api.service.ts` | listCampanas con parámetro concesionarioId |
| `leads-admin.controller.ts` | Llamada a listCampanas actualizada |
| `crm-config.dto.ts` | LeadcarsConfigDto alineado con tipos reales |