### PR TITLE
fix: notificaciones websocket en lista de visitantes y permitir localhost:puerto como dominio

### DIFF
--- a/.playwright-mcp/page-2026-06-11T15-32-01-382Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-32-01-382Z.yml
@@ -1,0 +1,71 @@
+- generic [active] [ref=e1]:
+  - link "Saltar al contenido" [ref=e2] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e3]:
+    - banner [ref=e4]:
+      - generic [ref=e7]:
+        - paragraph [ref=e8]:
+          - link "Guiders WP Test" [ref=e9] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e11]:
+          - list [ref=e16]:
+            - list [ref=e17]:
+              - listitem [ref=e18]:
+                - link "Página de ejemplo" [ref=e19] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e20]:
+                - link "Precios" [ref=e21] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e22]:
+      - heading "Blog" [level=1] [ref=e23]
+      - list [ref=e25]:
+        - listitem [ref=e26]:
+          - generic [ref=e27]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e28]:
+              - link "¡Hola, mundo!" [ref=e29] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e31]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e33]:
+              - link "25 de noviembre de 2025" [ref=e34] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e36]:
+      - generic [ref=e38]:
+        - generic [ref=e39]:
+          - heading "Guiders WP Test" [level=2] [ref=e42]:
+            - link "Guiders WP Test" [ref=e43] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e44]:
+            - navigation [ref=e45]:
+              - list [ref=e46]:
+                - listitem [ref=e47]:
+                  - link "Blog" [ref=e48] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e49]:
+                  - link "Acerca de" [ref=e50] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e51]:
+                  - link "FAQs" [ref=e52] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e53]:
+                  - link "Autores" [ref=e54] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e55]:
+              - list [ref=e56]:
+                - listitem [ref=e57]:
+                  - link "Eventos" [ref=e58] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e59]:
+                  - link "Tienda" [ref=e60] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e61]:
+                  - link "Patrones" [ref=e62] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e63]:
+                  - link "Temas" [ref=e64] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e66]:
+          - paragraph [ref=e67]: Twenty Twenty-Five
+          - paragraph [ref=e68]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e69] [cursor=pointer]:
+              - /url: https://es.wordpress.org

--- a/.playwright-mcp/page-2026-06-11T15-32-34-024Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-32-34-024Z.yml
@@ -1,0 +1,73 @@
+- generic [active] [ref=e1]:
+  - link "Saltar al contenido" [ref=e2] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e3]:
+    - banner [ref=e4]:
+      - generic [ref=e7]:
+        - paragraph [ref=e8]:
+          - link "Guiders WP Test" [ref=e9] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e11]:
+          - list [ref=e16]:
+            - list [ref=e17]:
+              - listitem [ref=e18]:
+                - link "Página de ejemplo" [ref=e19] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e20]:
+                - link "Precios" [ref=e21] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e22]:
+      - heading "Blog" [level=1] [ref=e23]
+      - list [ref=e25]:
+        - listitem [ref=e26]:
+          - generic [ref=e27]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e28]:
+              - link "¡Hola, mundo!" [ref=e29] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e31]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e33]:
+              - link "25 de noviembre de 2025" [ref=e34] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e36]:
+      - generic [ref=e38]:
+        - generic [ref=e39]:
+          - heading "Guiders WP Test" [level=2] [ref=e42]:
+            - link "Guiders WP Test" [ref=e43] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e44]:
+            - navigation [ref=e45]:
+              - list [ref=e46]:
+                - listitem [ref=e47]:
+                  - link "Blog" [ref=e48] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e49]:
+                  - link "Acerca de" [ref=e50] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e51]:
+                  - link "FAQs" [ref=e52] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e53]:
+                  - link "Autores" [ref=e54] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e55]:
+              - list [ref=e56]:
+                - listitem [ref=e57]:
+                  - link "Eventos" [ref=e58] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e59]:
+                  - link "Tienda" [ref=e60] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e61]:
+                  - link "Patrones" [ref=e62] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e63]:
+                  - link "Temas" [ref=e64] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e66]:
+          - paragraph [ref=e67]: Twenty Twenty-Five
+          - paragraph [ref=e68]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e69] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - button "Cambiar los ajustes de cookies" [ref=e80]:
+    - img [ref=e82]

--- a/.playwright-mcp/page-2026-06-11T15-33-47-105Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-33-47-105Z.yml
@@ -1,0 +1,34 @@
+- generic [active] [ref=e1]:
+  - heading "Acceder" [level=1] [ref=e2]
+  - generic [ref=e3]:
+    - link "Funciona con WordPress" [ref=e4] [cursor=pointer]:
+      - /url: https://es.wordpress.org/
+    - generic [ref=e5]:
+      - paragraph [ref=e6]:
+        - generic [ref=e7]: Nombre de usuario o correo electrónico
+        - textbox "Nombre de usuario o correo electrónico" [ref=e8]
+      - generic [ref=e9]:
+        - generic [ref=e10]: Contraseña
+        - generic [ref=e11]:
+          - textbox "Contraseña" [ref=e12]
+          - button "Mostrar la contraseña" [ref=e13] [cursor=pointer]:
+            - generic [ref=e14]: 
+      - paragraph [ref=e15]:
+        - checkbox "Recuérdame" [ref=e16] [cursor=pointer]
+        - generic [ref=e17]: Recuérdame
+      - paragraph:
+        - button "Acceder" [ref=e18] [cursor=pointer]
+    - paragraph [ref=e19]:
+      - link "¿Has olvidado tu contraseña?" [ref=e20] [cursor=pointer]:
+        - /url: http://localhost:8090/wp-login.php?action=lostpassword
+    - paragraph [ref=e21]:
+      - link "← Ir a Guiders WP Test" [ref=e22] [cursor=pointer]:
+        - /url: http://localhost:8090/
+  - generic [ref=e24]:
+    - generic [ref=e25]:
+      - generic [ref=e26]: 
+      - generic [ref=e27]: Idioma
+    - combobox "Idioma" [ref=e28] [cursor=pointer]:
+      - option "English (United States)"
+      - option "Español" [selected]
+    - button "Cambiar" [ref=e29] [cursor=pointer]

--- a/.playwright-mcp/page-2026-06-11T15-35-43-008Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-35-43-008Z.yml
@@ -1,0 +1,348 @@
+- generic [ref=e2]:
+  - navigation "Menú principal":
+    - link "Saltar al contenido principal" [ref=e3] [cursor=pointer]:
+      - /url: "#wpbody-content"
+    - link "Ir a la barra de herramientas" [ref=e4] [cursor=pointer]:
+      - /url: "#wp-toolbar"
+    - list [ref=e7]:
+      - listitem [ref=e8]:
+        - link "Escritorio" [ref=e9] [cursor=pointer]:
+          - /url: index.php
+          - generic [ref=e10]: 
+          - generic [ref=e11]: Escritorio
+        - list [ref=e12]:
+          - listitem [ref=e13]:
+            - link "Inicio" [ref=e14] [cursor=pointer]:
+              - /url: index.php
+          - listitem [ref=e15]:
+            - link "Actualizaciones 6" [ref=e16] [cursor=pointer]:
+              - /url: update-core.php
+              - text: Actualizaciones
+              - generic [ref=e17]: "6"
+      - listitem [ref=e18]
+      - listitem [ref=e20]:
+        - link "Entradas" [ref=e21] [cursor=pointer]:
+          - /url: edit.php
+          - generic [ref=e22]: 
+          - generic [ref=e23]: Entradas
+        - list [ref=e24]:
+          - listitem [ref=e25]:
+            - link "Todas las entradas" [ref=e26] [cursor=pointer]:
+              - /url: edit.php
+          - listitem [ref=e27]:
+            - link "Añadir entrada" [ref=e28] [cursor=pointer]:
+              - /url: post-new.php
+          - listitem [ref=e29]:
+            - link "Categorías" [ref=e30] [cursor=pointer]:
+              - /url: edit-tags.php?taxonomy=category
+          - listitem [ref=e31]:
+            - link "Etiquetas" [ref=e32] [cursor=pointer]:
+              - /url: edit-tags.php?taxonomy=post_tag
+      - listitem [ref=e33]:
+        - link "Medios" [ref=e34] [cursor=pointer]:
+          - /url: upload.php
+          - generic [ref=e35]: 
+          - generic [ref=e36]: Medios
+        - list [ref=e37]:
+          - listitem [ref=e38]:
+            - link "Biblioteca" [ref=e39] [cursor=pointer]:
+              - /url: upload.php
+          - listitem [ref=e40]:
+            - link "Añadir archivo de medios" [ref=e41] [cursor=pointer]:
+              - /url: media-new.php
+      - listitem [ref=e42]:
+        - link "Páginas" [ref=e43] [cursor=pointer]:
+          - /url: edit.php?post_type=page
+          - generic [ref=e44]: 
+          - generic [ref=e45]: Páginas
+        - list [ref=e46]:
+          - listitem [ref=e47]:
+            - link "Todas las páginas" [ref=e48] [cursor=pointer]:
+              - /url: edit.php?post_type=page
+          - listitem [ref=e49]:
+            - link "Añadir página" [ref=e50] [cursor=pointer]:
+              - /url: post-new.php?post_type=page
+      - listitem [ref=e51]:
+        - link "Comentarios" [ref=e52] [cursor=pointer]:
+          - /url: edit-comments.php
+          - generic [ref=e53]: 
+          - generic [ref=e54]: Comentarios
+      - listitem [ref=e55]
+      - listitem [ref=e57]:
+        - link "Apariencia" [ref=e58] [cursor=pointer]:
+          - /url: themes.php
+          - generic [ref=e59]: 
+          - generic [ref=e60]: Apariencia
+        - list [ref=e61]:
+          - listitem [ref=e62]:
+            - link "Temas 2" [ref=e63] [cursor=pointer]:
+              - /url: themes.php
+              - text: Temas
+              - generic [ref=e64]: "2"
+          - listitem [ref=e65]:
+            - link "Editor" [ref=e66] [cursor=pointer]:
+              - /url: site-editor.php
+      - listitem [ref=e67]:
+        - link "Plugins 2" [ref=e68] [cursor=pointer]:
+          - /url: plugins.php
+          - generic [ref=e69]: 
+          - generic [ref=e70]:
+            - text: Plugins
+            - generic [ref=e71]: "2"
+        - list [ref=e72]:
+          - listitem [ref=e73]:
+            - link "Plugins instalados" [ref=e74] [cursor=pointer]:
+              - /url: plugins.php
+          - listitem [ref=e75]:
+            - link "Añadir plugin" [ref=e76] [cursor=pointer]:
+              - /url: plugin-install.php
+      - listitem [ref=e77]:
+        - link "Usuarios" [ref=e78] [cursor=pointer]:
+          - /url: users.php
+          - generic [ref=e79]: 
+          - generic [ref=e80]: Usuarios
+        - list [ref=e81]:
+          - listitem [ref=e82]:
+            - link "Todos los usuarios" [ref=e83] [cursor=pointer]:
+              - /url: users.php
+          - listitem [ref=e84]:
+            - link "Añadir usuario" [ref=e85] [cursor=pointer]:
+              - /url: user-new.php
+          - listitem [ref=e86]:
+            - link "Perfil" [ref=e87] [cursor=pointer]:
+              - /url: profile.php
+      - listitem [ref=e88]:
+        - link "Herramientas" [ref=e89] [cursor=pointer]:
+          - /url: tools.php
+          - generic [ref=e90]: 
+          - generic [ref=e91]: Herramientas
+        - list [ref=e92]:
+          - listitem [ref=e93]:
+            - link "Herramientas disponibles" [ref=e94] [cursor=pointer]:
+              - /url: tools.php
+          - listitem [ref=e95]:
+            - link "Importar" [ref=e96] [cursor=pointer]:
+              - /url: import.php
+          - listitem [ref=e97]:
+            - link "Exportar" [ref=e98] [cursor=pointer]:
+              - /url: export.php
+          - listitem [ref=e99]:
+            - link "Salud del sitio" [ref=e100] [cursor=pointer]:
+              - /url: site-health.php
+          - listitem [ref=e101]:
+            - link "Exportar los datos personales" [ref=e102] [cursor=pointer]:
+              - /url: export-personal-data.php
+          - listitem [ref=e103]:
+            - link "Borrar los datos personales" [ref=e104] [cursor=pointer]:
+              - /url: erase-personal-data.php
+          - listitem [ref=e105]:
+            - link "Editor de archivos de temas" [ref=e106] [cursor=pointer]:
+              - /url: theme-editor.php
+          - listitem [ref=e107]:
+            - link "Editor de archivos de plugins" [ref=e108] [cursor=pointer]:
+              - /url: plugin-editor.php
+      - listitem [ref=e109]:
+        - link "Ajustes" [ref=e110] [cursor=pointer]:
+          - /url: options-general.php
+          - generic [ref=e111]: 
+          - generic [ref=e112]: Ajustes
+        - list [ref=e113]:
+          - listitem [ref=e114]:
+            - link "Generales" [ref=e115] [cursor=pointer]:
+              - /url: options-general.php
+          - listitem [ref=e116]:
+            - link "Escritura" [ref=e117] [cursor=pointer]:
+              - /url: options-writing.php
+          - listitem [ref=e118]:
+            - link "Lectura" [ref=e119] [cursor=pointer]:
+              - /url: options-reading.php
+          - listitem [ref=e120]:
+            - link "Comentarios" [ref=e121] [cursor=pointer]:
+              - /url: options-discussion.php
+          - listitem [ref=e122]:
+            - link "Medios" [ref=e123] [cursor=pointer]:
+              - /url: options-media.php
+          - listitem [ref=e124]:
+            - link "Enlaces permanentes" [ref=e125] [cursor=pointer]:
+              - /url: options-permalink.php
+          - listitem [ref=e126]:
+            - link "Privacidad" [ref=e127] [cursor=pointer]:
+              - /url: options-privacy.php
+          - listitem [ref=e128]:
+            - link "Guiders SDK" [ref=e129] [cursor=pointer]:
+              - /url: options-general.php?page=guiders-settings
+      - listitem [ref=e130]:
+        - link "GDPR Cookie Compliance" [ref=e131] [cursor=pointer]:
+          - /url: admin.php?page=moove-gdpr
+          - generic [ref=e133]: GDPR Cookie Compliance
+        - list [ref=e134]:
+          - listitem [ref=e135]:
+            - link "GDPR Cookie Compliance" [ref=e136] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr
+          - listitem [ref=e137]:
+            - link "Documentación" [ref=e138] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_help
+          - listitem [ref=e139]:
+            - link "Tutorial en vídeo" [ref=e140] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_video-tutorial
+          - listitem [ref=e141]:
+            - link "Soporte" [ref=e142] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_support
+          - listitem [ref=e143]:
+            - link "Gestor de licencias" [ref=e144] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_licence
+      - listitem [ref=e145]:
+        - button "Contraer el menú principal" [expanded] [ref=e146] [cursor=pointer]:
+          - generic [ref=e147]: 
+          - generic [ref=e148]: Cerrar menú
+  - generic [ref=e149]:
+    - generic [ref=e150]:
+      - navigation "Barra de herramientas":
+        - menu:
+          - group [ref=e151]:
+            - menuitem "Acerca de WordPress" [ref=e152] [cursor=pointer]:
+              - generic [ref=e153]: 
+              - generic [ref=e154]: Acerca de WordPress
+          - group [ref=e155]:
+            - menuitem " Guiders WP Test" [ref=e156] [cursor=pointer]
+          - group [ref=e157]:
+            - menuitem "6 actualizaciones disponibles" [ref=e158] [cursor=pointer]:
+              - generic [ref=e159]: 
+              - generic [ref=e160]: "6"
+              - generic [ref=e161]: 6 actualizaciones disponibles
+          - group [ref=e162]:
+            - menuitem "0 comentarios en moderación" [ref=e163] [cursor=pointer]:
+              - generic [ref=e164]: 
+              - generic [ref=e165]: "0"
+              - generic [ref=e166]: 0 comentarios en moderación
+          - group [ref=e167]:
+            - menuitem "Añadir" [ref=e168] [cursor=pointer]:
+              - generic [ref=e169]: 
+              - generic [ref=e170]: Añadir
+        - menu [ref=e171]:
+          - group [ref=e172]:
+            - menuitem "Hola, Roger Puga Ruiz" [ref=e173] [cursor=pointer]
+    - main [ref=e174]:
+      - generic [ref=e175]:
+        - generic [ref=e176]:
+          - text: ¡Ya está disponible
+          - link "WordPress 7.0" [ref=e177] [cursor=pointer]:
+            - /url: https://wordpress.org/documentation/wordpress-version/version-7-0/
+          - text: "!"
+          - link "Por favor, actualiza WordPress ahora" [ref=e178] [cursor=pointer]:
+            - /url: http://localhost:8090/wp-admin/update-core.php
+            - text: Por favor, actualiza ahora
+          - text: .
+        - generic [ref=e179]:
+          - heading "Guiders SDK" [level=1] [ref=e180]
+          - generic [ref=e181]:
+            - heading "Configuración del SDK de Guiders" [level=2] [ref=e182]
+            - paragraph [ref=e183]: Configura el SDK de Guiders para habilitar tracking inteligente, chat en vivo y notificaciones en tu sitio WordPress.
+          - navigation [ref=e184]:
+            - link " General" [ref=e185] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=general"
+              - generic [ref=e186]: 
+              - text: General
+            - link " Chat" [ref=e187] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=chat"
+              - generic [ref=e188]: 
+              - text: Chat
+            - link " Tracking" [ref=e189] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=tracking"
+              - generic [ref=e190]: 
+              - text: Tracking
+            - link " Cookies & GDPR" [ref=e191] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=cookies"
+              - generic [ref=e192]: 
+              - text: Cookies & GDPR
+          - generic [ref=e193]:
+            - generic [ref=e195]:
+              - heading "Configuración General" [level=2] [ref=e196]
+              - paragraph [ref=e197]: Configura las opciones básicas del SDK de Guiders.
+              - text: API Key
+              - textbox [ref=e198]: 49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d9763
+              - paragraph [ref=e199]: Tu API Key de Guiders. Obténla desde tu panel de control de Guiders.
+              - text: Habilitar Guiders SDK
+              - checkbox "Habilitar el SDK de Guiders en tu sitio web" [checked] [ref=e200] [cursor=pointer]
+              - text: Habilitar el SDK de Guiders en tu sitio web Entorno
+              - combobox [ref=e201] [cursor=pointer]:
+                - option "Producción"
+                - option "Desarrollo" [selected]
+              - paragraph [ref=e202]: Selecciona el entorno. Usa "Desarrollo" solo para pruebas locales.
+              - text: Modo de Auto-Init
+              - combobox [ref=e203] [cursor=pointer]:
+                - option "Inmediato (tan pronto cargue el script)"
+                - option "DOM Ready (DOMContentLoaded)" [selected]
+                - option "Delay Personalizado"
+                - option "Manual (lo iniciaré yo)"
+              - paragraph [ref=e204]: "Controla cuándo se inicializa el SDK: inmediato, al estar listo el DOM, con delay o manual."
+              - paragraph [ref=e205]:
+                - button "Guardar Configuración" [ref=e206] [cursor=pointer]
+            - generic [ref=e207]:
+              - generic [ref=e208]:
+                - heading "Configuración Básica" [level=3] [ref=e209]
+                - paragraph [ref=e210]: Comienza configurando tu API Key de Guiders para habilitar todas las funcionalidades del SDK.
+                - list [ref=e211]:
+                  - listitem [ref=e212]:
+                    - text: ⭐
+                    - strong [ref=e213]: "API Key:"
+                    - text: Requerida para todas las funciones
+                  - listitem [ref=e214]:
+                    - text: 🔧
+                    - strong [ref=e215]: "Entorno:"
+                    - text: Usa "production" para sitios en vivo
+                  - listitem [ref=e216]:
+                    - text: ⚡
+                    - strong [ref=e217]: "Auto-Init:"
+                    - text: Controla cuándo se carga el SDK
+              - generic [ref=e218]:
+                - heading "Modos de Auto-Inicialización" [level=3] [ref=e219]
+                - list [ref=e220]:
+                  - listitem [ref=e221]:
+                    - strong [ref=e222]: "immediate:"
+                    - text: Carga instantánea (más rápido)
+                  - listitem [ref=e223]:
+                    - strong [ref=e224]: "domready:"
+                    - text: Espera al DOM (recomendado)
+                  - listitem [ref=e225]:
+                    - strong [ref=e226]: "delayed:"
+                    - text: Retraso personalizado (ms)
+                  - listitem [ref=e227]:
+                    - strong [ref=e228]: "manual:"
+                    - text: Control total via JavaScript
+              - generic [ref=e229]:
+                - heading "Información del Plugin" [level=3] [ref=e230]
+                - paragraph [ref=e231]:
+                  - strong [ref=e232]: "Versión actual:"
+                  - text: v2.13.2
+                - paragraph [ref=e233]: ✅ Plugin actualizado
+                - paragraph [ref=e234]:
+                  - link "🔍 Verificar actualizaciones" [ref=e235] [cursor=pointer]:
+                    - /url: http://localhost:8090/wp-admin/plugins.php?force-check=1
+              - generic [ref=e236]:
+                - heading "Soporte y Documentación" [level=3] [ref=e237]
+                - list [ref=e238]:
+                  - listitem [ref=e239]:
+                    - link "📚 Documentación completa" [ref=e240] [cursor=pointer]:
+                      - /url: https://github.com/RogerPugaRuiz/guiders-sdk
+                  - listitem [ref=e241]:
+                    - link "🌐 Sitio web oficial" [ref=e242] [cursor=pointer]:
+                      - /url: https://guiders.ancoradual.com
+                  - listitem [ref=e243]:
+                    - link "🐛 Reportar problemas" [ref=e244] [cursor=pointer]:
+                      - /url: https://github.com/RogerPugaRuiz/guiders-sdk/issues
+                  - listitem [ref=e245]:
+                    - link "📋 Ver versiones" [ref=e246] [cursor=pointer]:
+                      - /url: https://github.com/RogerPugaRuiz/guiders-sdk/releases
+  - contentinfo [ref=e247]:
+    - paragraph [ref=e248]:
+      - generic [ref=e249]:
+        - text: Gracias por crear con
+        - link "WordPress" [ref=e250] [cursor=pointer]:
+          - /url: https://es.wordpress.org/
+        - text: .
+    - paragraph [ref=e251]:
+      - strong [ref=e252]:
+        - link "Obtener la versión 7.0" [ref=e253] [cursor=pointer]:
+          - /url: http://localhost:8090/wp-admin/update-core.php
+  - text: 

--- a/.playwright-mcp/page-2026-06-11T15-36-48-766Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-36-48-766Z.yml
@@ -1,0 +1,359 @@
+- generic [ref=e2]:
+  - navigation "Menú principal":
+    - link "Saltar al contenido principal" [ref=e3] [cursor=pointer]:
+      - /url: "#wpbody-content"
+    - link "Ir a la barra de herramientas" [ref=e4] [cursor=pointer]:
+      - /url: "#wp-toolbar"
+    - list [ref=e7]:
+      - listitem [ref=e8]:
+        - link "Escritorio" [ref=e9] [cursor=pointer]:
+          - /url: index.php
+          - generic [ref=e10]: 
+          - generic [ref=e11]: Escritorio
+        - list [ref=e12]:
+          - listitem [ref=e13]:
+            - link "Inicio" [ref=e14] [cursor=pointer]:
+              - /url: index.php
+          - listitem [ref=e15]:
+            - link "Actualizaciones 6" [ref=e16] [cursor=pointer]:
+              - /url: update-core.php
+              - text: Actualizaciones
+              - generic [ref=e17]: "6"
+      - listitem [ref=e18]
+      - listitem [ref=e20]:
+        - link "Entradas" [ref=e21] [cursor=pointer]:
+          - /url: edit.php
+          - generic [ref=e22]: 
+          - generic [ref=e23]: Entradas
+        - list [ref=e24]:
+          - listitem [ref=e25]:
+            - link "Todas las entradas" [ref=e26] [cursor=pointer]:
+              - /url: edit.php
+          - listitem [ref=e27]:
+            - link "Añadir entrada" [ref=e28] [cursor=pointer]:
+              - /url: post-new.php
+          - listitem [ref=e29]:
+            - link "Categorías" [ref=e30] [cursor=pointer]:
+              - /url: edit-tags.php?taxonomy=category
+          - listitem [ref=e31]:
+            - link "Etiquetas" [ref=e32] [cursor=pointer]:
+              - /url: edit-tags.php?taxonomy=post_tag
+      - listitem [ref=e33]:
+        - link "Medios" [ref=e34] [cursor=pointer]:
+          - /url: upload.php
+          - generic [ref=e35]: 
+          - generic [ref=e36]: Medios
+        - list [ref=e37]:
+          - listitem [ref=e38]:
+            - link "Biblioteca" [ref=e39] [cursor=pointer]:
+              - /url: upload.php
+          - listitem [ref=e40]:
+            - link "Añadir archivo de medios" [ref=e41] [cursor=pointer]:
+              - /url: media-new.php
+      - listitem [ref=e42]:
+        - link "Páginas" [ref=e43] [cursor=pointer]:
+          - /url: edit.php?post_type=page
+          - generic [ref=e44]: 
+          - generic [ref=e45]: Páginas
+        - list [ref=e46]:
+          - listitem [ref=e47]:
+            - link "Todas las páginas" [ref=e48] [cursor=pointer]:
+              - /url: edit.php?post_type=page
+          - listitem [ref=e49]:
+            - link "Añadir página" [ref=e50] [cursor=pointer]:
+              - /url: post-new.php?post_type=page
+      - listitem [ref=e51]:
+        - link "Comentarios" [ref=e52] [cursor=pointer]:
+          - /url: edit-comments.php
+          - generic [ref=e53]: 
+          - generic [ref=e54]: Comentarios
+      - listitem [ref=e55]
+      - listitem [ref=e57]:
+        - link "Apariencia" [ref=e58] [cursor=pointer]:
+          - /url: themes.php
+          - generic [ref=e59]: 
+          - generic [ref=e60]: Apariencia
+        - list [ref=e61]:
+          - listitem [ref=e62]:
+            - link "Temas 2" [ref=e63] [cursor=pointer]:
+              - /url: themes.php
+              - text: Temas
+              - generic [ref=e64]: "2"
+          - listitem [ref=e65]:
+            - link "Editor" [ref=e66] [cursor=pointer]:
+              - /url: site-editor.php
+      - listitem [ref=e67]:
+        - link "Plugins 2" [ref=e68] [cursor=pointer]:
+          - /url: plugins.php
+          - generic [ref=e69]: 
+          - generic [ref=e70]:
+            - text: Plugins
+            - generic [ref=e71]: "2"
+        - list [ref=e72]:
+          - listitem [ref=e73]:
+            - link "Plugins instalados" [ref=e74] [cursor=pointer]:
+              - /url: plugins.php
+          - listitem [ref=e75]:
+            - link "Añadir plugin" [ref=e76] [cursor=pointer]:
+              - /url: plugin-install.php
+      - listitem [ref=e77]:
+        - link "Usuarios" [ref=e78] [cursor=pointer]:
+          - /url: users.php
+          - generic [ref=e79]: 
+          - generic [ref=e80]: Usuarios
+        - list [ref=e81]:
+          - listitem [ref=e82]:
+            - link "Todos los usuarios" [ref=e83] [cursor=pointer]:
+              - /url: users.php
+          - listitem [ref=e84]:
+            - link "Añadir usuario" [ref=e85] [cursor=pointer]:
+              - /url: user-new.php
+          - listitem [ref=e86]:
+            - link "Perfil" [ref=e87] [cursor=pointer]:
+              - /url: profile.php
+      - listitem [ref=e88]:
+        - link "Herramientas" [ref=e89] [cursor=pointer]:
+          - /url: tools.php
+          - generic [ref=e90]: 
+          - generic [ref=e91]: Herramientas
+        - list [ref=e92]:
+          - listitem [ref=e93]:
+            - link "Herramientas disponibles" [ref=e94] [cursor=pointer]:
+              - /url: tools.php
+          - listitem [ref=e95]:
+            - link "Importar" [ref=e96] [cursor=pointer]:
+              - /url: import.php
+          - listitem [ref=e97]:
+            - link "Exportar" [ref=e98] [cursor=pointer]:
+              - /url: export.php
+          - listitem [ref=e99]:
+            - link "Salud del sitio" [ref=e100] [cursor=pointer]:
+              - /url: site-health.php
+          - listitem [ref=e101]:
+            - link "Exportar los datos personales" [ref=e102] [cursor=pointer]:
+              - /url: export-personal-data.php
+          - listitem [ref=e103]:
+            - link "Borrar los datos personales" [ref=e104] [cursor=pointer]:
+              - /url: erase-personal-data.php
+          - listitem [ref=e105]:
+            - link "Editor de archivos de temas" [ref=e106] [cursor=pointer]:
+              - /url: theme-editor.php
+          - listitem [ref=e107]:
+            - link "Editor de archivos de plugins" [ref=e108] [cursor=pointer]:
+              - /url: plugin-editor.php
+      - listitem [ref=e109]:
+        - link "Ajustes" [ref=e110] [cursor=pointer]:
+          - /url: options-general.php
+          - generic [ref=e111]: 
+          - generic [ref=e112]: Ajustes
+        - list [ref=e113]:
+          - listitem [ref=e114]:
+            - link "Generales" [ref=e115] [cursor=pointer]:
+              - /url: options-general.php
+          - listitem [ref=e116]:
+            - link "Escritura" [ref=e117] [cursor=pointer]:
+              - /url: options-writing.php
+          - listitem [ref=e118]:
+            - link "Lectura" [ref=e119] [cursor=pointer]:
+              - /url: options-reading.php
+          - listitem [ref=e120]:
+            - link "Comentarios" [ref=e121] [cursor=pointer]:
+              - /url: options-discussion.php
+          - listitem [ref=e122]:
+            - link "Medios" [ref=e123] [cursor=pointer]:
+              - /url: options-media.php
+          - listitem [ref=e124]:
+            - link "Enlaces permanentes" [ref=e125] [cursor=pointer]:
+              - /url: options-permalink.php
+          - listitem [ref=e126]:
+            - link "Privacidad" [ref=e127] [cursor=pointer]:
+              - /url: options-privacy.php
+          - listitem [ref=e128]:
+            - link "Guiders SDK" [ref=e129] [cursor=pointer]:
+              - /url: options-general.php?page=guiders-settings
+      - listitem [ref=e130]:
+        - link "GDPR Cookie Compliance" [ref=e131] [cursor=pointer]:
+          - /url: admin.php?page=moove-gdpr
+          - generic [ref=e133]: GDPR Cookie Compliance
+        - list [ref=e134]:
+          - listitem [ref=e135]:
+            - link "GDPR Cookie Compliance" [ref=e136] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr
+          - listitem [ref=e137]:
+            - link "Documentación" [ref=e138] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_help
+          - listitem [ref=e139]:
+            - link "Tutorial en vídeo" [ref=e140] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_video-tutorial
+          - listitem [ref=e141]:
+            - link "Soporte" [ref=e142] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_support
+          - listitem [ref=e143]:
+            - link "Gestor de licencias" [ref=e144] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_licence
+      - listitem [ref=e145]:
+        - button "Contraer el menú principal" [expanded] [ref=e146] [cursor=pointer]:
+          - generic [ref=e147]: 
+          - generic [ref=e148]: Cerrar menú
+  - generic [ref=e149]:
+    - generic [ref=e150]:
+      - navigation "Barra de herramientas":
+        - menu:
+          - group [ref=e151]:
+            - menuitem "Acerca de WordPress" [ref=e152] [cursor=pointer]:
+              - generic [ref=e153]: 
+              - generic [ref=e154]: Acerca de WordPress
+          - group [ref=e155]:
+            - menuitem " Guiders WP Test" [ref=e156] [cursor=pointer]
+          - group [ref=e157]:
+            - menuitem "6 actualizaciones disponibles" [ref=e158] [cursor=pointer]:
+              - generic [ref=e159]: 
+              - generic [ref=e160]: "6"
+              - generic [ref=e161]: 6 actualizaciones disponibles
+          - group [ref=e162]:
+            - menuitem "0 comentarios en moderación" [ref=e163] [cursor=pointer]:
+              - generic [ref=e164]: 
+              - generic [ref=e165]: "0"
+              - generic [ref=e166]: 0 comentarios en moderación
+          - group [ref=e167]:
+            - menuitem "Añadir" [ref=e168] [cursor=pointer]:
+              - generic [ref=e169]: 
+              - generic [ref=e170]: Añadir
+        - menu [ref=e171]:
+          - group [ref=e172]:
+            - menuitem "Hola, Roger Puga Ruiz" [ref=e173] [cursor=pointer]
+    - main [ref=e174]:
+      - generic [ref=e175]:
+        - generic [ref=e176]:
+          - text: ¡Ya está disponible
+          - link "WordPress 7.0" [ref=e177] [cursor=pointer]:
+            - /url: https://wordpress.org/documentation/wordpress-version/version-7-0/
+          - text: "!"
+          - link "Por favor, actualiza WordPress ahora" [ref=e178] [cursor=pointer]:
+            - /url: http://localhost:8090/wp-admin/update-core.php
+            - text: Por favor, actualiza ahora
+          - text: .
+        - generic [ref=e179]:
+          - heading "Guiders SDK" [level=1] [ref=e180]
+          - generic [ref=e181]:
+            - paragraph [ref=e182]: Configuración de Guiders SDK guardada correctamente.
+            - button " Descartar este aviso." [ref=e183] [cursor=pointer]:
+              - text: 
+              - generic [ref=e184]: Descartar este aviso.
+          - generic [ref=e185]:
+            - paragraph [ref=e186]:
+              - strong [ref=e187]: Ajustes guardados.
+            - button " Descartar este aviso." [ref=e188] [cursor=pointer]:
+              - text: 
+              - generic [ref=e189]: Descartar este aviso.
+          - generic [ref=e190]:
+            - heading "Configuración del SDK de Guiders" [level=2] [ref=e191]
+            - paragraph [ref=e192]: Configura el SDK de Guiders para habilitar tracking inteligente, chat en vivo y notificaciones en tu sitio WordPress.
+          - navigation [ref=e193]:
+            - link " General" [ref=e194] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=general"
+              - generic [ref=e195]: 
+              - text: General
+            - link " Chat" [ref=e196] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=chat"
+              - generic [ref=e197]: 
+              - text: Chat
+            - link " Tracking" [ref=e198] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=tracking"
+              - generic [ref=e199]: 
+              - text: Tracking
+            - link " Cookies & GDPR" [ref=e200] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=cookies"
+              - generic [ref=e201]: 
+              - text: Cookies & GDPR
+          - generic [ref=e202]:
+            - generic [ref=e204]:
+              - heading "Configuración General" [level=2] [ref=e205]
+              - paragraph [ref=e206]: Configura las opciones básicas del SDK de Guiders.
+              - text: API Key
+              - textbox [ref=e207]: 7a8f08e6b704a17adccd75f1d203a95c9b7d89fff94ad6bfa4de77f3079586ff
+              - paragraph [ref=e208]: Tu API Key de Guiders. Obténla desde tu panel de control de Guiders.
+              - text: Habilitar Guiders SDK
+              - checkbox "Habilitar el SDK de Guiders en tu sitio web" [checked] [ref=e209] [cursor=pointer]
+              - text: Habilitar el SDK de Guiders en tu sitio web Entorno
+              - combobox [ref=e210] [cursor=pointer]:
+                - option "Producción"
+                - option "Desarrollo" [selected]
+              - paragraph [ref=e211]: Selecciona el entorno. Usa "Desarrollo" solo para pruebas locales.
+              - text: Modo de Auto-Init
+              - combobox [ref=e212] [cursor=pointer]:
+                - option "Inmediato (tan pronto cargue el script)"
+                - option "DOM Ready (DOMContentLoaded)" [selected]
+                - option "Delay Personalizado"
+                - option "Manual (lo iniciaré yo)"
+              - paragraph [ref=e213]: "Controla cuándo se inicializa el SDK: inmediato, al estar listo el DOM, con delay o manual."
+              - paragraph [ref=e214]:
+                - button "Guardar Configuración" [ref=e215] [cursor=pointer]
+            - generic [ref=e216]:
+              - generic [ref=e217]:
+                - heading "Configuración Básica" [level=3] [ref=e218]
+                - paragraph [ref=e219]: Comienza configurando tu API Key de Guiders para habilitar todas las funcionalidades del SDK.
+                - list [ref=e220]:
+                  - listitem [ref=e221]:
+                    - text: ⭐
+                    - strong [ref=e222]: "API Key:"
+                    - text: Requerida para todas las funciones
+                  - listitem [ref=e223]:
+                    - text: 🔧
+                    - strong [ref=e224]: "Entorno:"
+                    - text: Usa "production" para sitios en vivo
+                  - listitem [ref=e225]:
+                    - text: ⚡
+                    - strong [ref=e226]: "Auto-Init:"
+                    - text: Controla cuándo se carga el SDK
+              - generic [ref=e227]:
+                - heading "Modos de Auto-Inicialización" [level=3] [ref=e228]
+                - list [ref=e229]:
+                  - listitem [ref=e230]:
+                    - strong [ref=e231]: "immediate:"
+                    - text: Carga instantánea (más rápido)
+                  - listitem [ref=e232]:
+                    - strong [ref=e233]: "domready:"
+                    - text: Espera al DOM (recomendado)
+                  - listitem [ref=e234]:
+                    - strong [ref=e235]: "delayed:"
+                    - text: Retraso personalizado (ms)
+                  - listitem [ref=e236]:
+                    - strong [ref=e237]: "manual:"
+                    - text: Control total via JavaScript
+              - generic [ref=e238]:
+                - heading "Información del Plugin" [level=3] [ref=e239]
+                - paragraph [ref=e240]:
+                  - strong [ref=e241]: "Versión actual:"
+                  - text: v2.13.2
+                - paragraph [ref=e242]: ✅ Plugin actualizado
+                - paragraph [ref=e243]:
+                  - link "🔍 Verificar actualizaciones" [ref=e244] [cursor=pointer]:
+                    - /url: http://localhost:8090/wp-admin/plugins.php?force-check=1
+              - generic [ref=e245]:
+                - heading "Soporte y Documentación" [level=3] [ref=e246]
+                - list [ref=e247]:
+                  - listitem [ref=e248]:
+                    - link "📚 Documentación completa" [ref=e249] [cursor=pointer]:
+                      - /url: https://github.com/RogerPugaRuiz/guiders-sdk
+                  - listitem [ref=e250]:
+                    - link "🌐 Sitio web oficial" [ref=e251] [cursor=pointer]:
+                      - /url: https://guiders.ancoradual.com
+                  - listitem [ref=e252]:
+                    - link "🐛 Reportar problemas" [ref=e253] [cursor=pointer]:
+                      - /url: https://github.com/RogerPugaRuiz/guiders-sdk/issues
+                  - listitem [ref=e254]:
+                    - link "📋 Ver versiones" [ref=e255] [cursor=pointer]:
+                      - /url: https://github.com/RogerPugaRuiz/guiders-sdk/releases
+  - contentinfo [ref=e256]:
+    - paragraph [ref=e257]:
+      - generic [ref=e258]:
+        - text: Gracias por crear con
+        - link "WordPress" [ref=e259] [cursor=pointer]:
+          - /url: https://es.wordpress.org/
+        - text: .
+    - paragraph [ref=e260]:
+      - strong [ref=e261]:
+        - link "Obtener la versión 7.0" [ref=e262] [cursor=pointer]:
+          - /url: http://localhost:8090/wp-admin/update-core.php
+  - text: 

--- a/.playwright-mcp/page-2026-06-11T15-37-05-938Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-37-05-938Z.yml
@@ -1,0 +1,106 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - generic: 🎯 search_submit (90%)

--- a/.playwright-mcp/page-2026-06-11T15-37-13-534Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-37-13-534Z.yml
@@ -1,0 +1,348 @@
+- generic [ref=e2]:
+  - navigation "Menú principal":
+    - link "Saltar al contenido principal" [ref=e3] [cursor=pointer]:
+      - /url: "#wpbody-content"
+    - link "Ir a la barra de herramientas" [ref=e4] [cursor=pointer]:
+      - /url: "#wp-toolbar"
+    - list [ref=e7]:
+      - listitem [ref=e8]:
+        - link "Escritorio" [ref=e9] [cursor=pointer]:
+          - /url: index.php
+          - generic [ref=e10]: 
+          - generic [ref=e11]: Escritorio
+        - list [ref=e12]:
+          - listitem [ref=e13]:
+            - link "Inicio" [ref=e14] [cursor=pointer]:
+              - /url: index.php
+          - listitem [ref=e15]:
+            - link "Actualizaciones 6" [ref=e16] [cursor=pointer]:
+              - /url: update-core.php
+              - text: Actualizaciones
+              - generic [ref=e17]: "6"
+      - listitem [ref=e18]
+      - listitem [ref=e20]:
+        - link "Entradas" [ref=e21] [cursor=pointer]:
+          - /url: edit.php
+          - generic [ref=e22]: 
+          - generic [ref=e23]: Entradas
+        - list [ref=e24]:
+          - listitem [ref=e25]:
+            - link "Todas las entradas" [ref=e26] [cursor=pointer]:
+              - /url: edit.php
+          - listitem [ref=e27]:
+            - link "Añadir entrada" [ref=e28] [cursor=pointer]:
+              - /url: post-new.php
+          - listitem [ref=e29]:
+            - link "Categorías" [ref=e30] [cursor=pointer]:
+              - /url: edit-tags.php?taxonomy=category
+          - listitem [ref=e31]:
+            - link "Etiquetas" [ref=e32] [cursor=pointer]:
+              - /url: edit-tags.php?taxonomy=post_tag
+      - listitem [ref=e33]:
+        - link "Medios" [ref=e34] [cursor=pointer]:
+          - /url: upload.php
+          - generic [ref=e35]: 
+          - generic [ref=e36]: Medios
+        - list [ref=e37]:
+          - listitem [ref=e38]:
+            - link "Biblioteca" [ref=e39] [cursor=pointer]:
+              - /url: upload.php
+          - listitem [ref=e40]:
+            - link "Añadir archivo de medios" [ref=e41] [cursor=pointer]:
+              - /url: media-new.php
+      - listitem [ref=e42]:
+        - link "Páginas" [ref=e43] [cursor=pointer]:
+          - /url: edit.php?post_type=page
+          - generic [ref=e44]: 
+          - generic [ref=e45]: Páginas
+        - list [ref=e46]:
+          - listitem [ref=e47]:
+            - link "Todas las páginas" [ref=e48] [cursor=pointer]:
+              - /url: edit.php?post_type=page
+          - listitem [ref=e49]:
+            - link "Añadir página" [ref=e50] [cursor=pointer]:
+              - /url: post-new.php?post_type=page
+      - listitem [ref=e51]:
+        - link "Comentarios" [ref=e52] [cursor=pointer]:
+          - /url: edit-comments.php
+          - generic [ref=e53]: 
+          - generic [ref=e54]: Comentarios
+      - listitem [ref=e55]
+      - listitem [ref=e57]:
+        - link "Apariencia" [ref=e58] [cursor=pointer]:
+          - /url: themes.php
+          - generic [ref=e59]: 
+          - generic [ref=e60]: Apariencia
+        - list [ref=e61]:
+          - listitem [ref=e62]:
+            - link "Temas 2" [ref=e63] [cursor=pointer]:
+              - /url: themes.php
+              - text: Temas
+              - generic [ref=e64]: "2"
+          - listitem [ref=e65]:
+            - link "Editor" [ref=e66] [cursor=pointer]:
+              - /url: site-editor.php
+      - listitem [ref=e67]:
+        - link "Plugins 2" [ref=e68] [cursor=pointer]:
+          - /url: plugins.php
+          - generic [ref=e69]: 
+          - generic [ref=e70]:
+            - text: Plugins
+            - generic [ref=e71]: "2"
+        - list [ref=e72]:
+          - listitem [ref=e73]:
+            - link "Plugins instalados" [ref=e74] [cursor=pointer]:
+              - /url: plugins.php
+          - listitem [ref=e75]:
+            - link "Añadir plugin" [ref=e76] [cursor=pointer]:
+              - /url: plugin-install.php
+      - listitem [ref=e77]:
+        - link "Usuarios" [ref=e78] [cursor=pointer]:
+          - /url: users.php
+          - generic [ref=e79]: 
+          - generic [ref=e80]: Usuarios
+        - list [ref=e81]:
+          - listitem [ref=e82]:
+            - link "Todos los usuarios" [ref=e83] [cursor=pointer]:
+              - /url: users.php
+          - listitem [ref=e84]:
+            - link "Añadir usuario" [ref=e85] [cursor=pointer]:
+              - /url: user-new.php
+          - listitem [ref=e86]:
+            - link "Perfil" [ref=e87] [cursor=pointer]:
+              - /url: profile.php
+      - listitem [ref=e88]:
+        - link "Herramientas" [ref=e89] [cursor=pointer]:
+          - /url: tools.php
+          - generic [ref=e90]: 
+          - generic [ref=e91]: Herramientas
+        - list [ref=e92]:
+          - listitem [ref=e93]:
+            - link "Herramientas disponibles" [ref=e94] [cursor=pointer]:
+              - /url: tools.php
+          - listitem [ref=e95]:
+            - link "Importar" [ref=e96] [cursor=pointer]:
+              - /url: import.php
+          - listitem [ref=e97]:
+            - link "Exportar" [ref=e98] [cursor=pointer]:
+              - /url: export.php
+          - listitem [ref=e99]:
+            - link "Salud del sitio" [ref=e100] [cursor=pointer]:
+              - /url: site-health.php
+          - listitem [ref=e101]:
+            - link "Exportar los datos personales" [ref=e102] [cursor=pointer]:
+              - /url: export-personal-data.php
+          - listitem [ref=e103]:
+            - link "Borrar los datos personales" [ref=e104] [cursor=pointer]:
+              - /url: erase-personal-data.php
+          - listitem [ref=e105]:
+            - link "Editor de archivos de temas" [ref=e106] [cursor=pointer]:
+              - /url: theme-editor.php
+          - listitem [ref=e107]:
+            - link "Editor de archivos de plugins" [ref=e108] [cursor=pointer]:
+              - /url: plugin-editor.php
+      - listitem [ref=e109]:
+        - link "Ajustes" [ref=e110] [cursor=pointer]:
+          - /url: options-general.php
+          - generic [ref=e111]: 
+          - generic [ref=e112]: Ajustes
+        - list [ref=e113]:
+          - listitem [ref=e114]:
+            - link "Generales" [ref=e115] [cursor=pointer]:
+              - /url: options-general.php
+          - listitem [ref=e116]:
+            - link "Escritura" [ref=e117] [cursor=pointer]:
+              - /url: options-writing.php
+          - listitem [ref=e118]:
+            - link "Lectura" [ref=e119] [cursor=pointer]:
+              - /url: options-reading.php
+          - listitem [ref=e120]:
+            - link "Comentarios" [ref=e121] [cursor=pointer]:
+              - /url: options-discussion.php
+          - listitem [ref=e122]:
+            - link "Medios" [ref=e123] [cursor=pointer]:
+              - /url: options-media.php
+          - listitem [ref=e124]:
+            - link "Enlaces permanentes" [ref=e125] [cursor=pointer]:
+              - /url: options-permalink.php
+          - listitem [ref=e126]:
+            - link "Privacidad" [ref=e127] [cursor=pointer]:
+              - /url: options-privacy.php
+          - listitem [ref=e128]:
+            - link "Guiders SDK" [ref=e129] [cursor=pointer]:
+              - /url: options-general.php?page=guiders-settings
+      - listitem [ref=e130]:
+        - link "GDPR Cookie Compliance" [ref=e131] [cursor=pointer]:
+          - /url: admin.php?page=moove-gdpr
+          - generic [ref=e133]: GDPR Cookie Compliance
+        - list [ref=e134]:
+          - listitem [ref=e135]:
+            - link "GDPR Cookie Compliance" [ref=e136] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr
+          - listitem [ref=e137]:
+            - link "Documentación" [ref=e138] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_help
+          - listitem [ref=e139]:
+            - link "Tutorial en vídeo" [ref=e140] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_video-tutorial
+          - listitem [ref=e141]:
+            - link "Soporte" [ref=e142] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_support
+          - listitem [ref=e143]:
+            - link "Gestor de licencias" [ref=e144] [cursor=pointer]:
+              - /url: admin.php?page=moove-gdpr_licence
+      - listitem [ref=e145]:
+        - button "Contraer el menú principal" [expanded] [ref=e146] [cursor=pointer]:
+          - generic [ref=e147]: 
+          - generic [ref=e148]: Cerrar menú
+  - generic [ref=e149]:
+    - generic [ref=e150]:
+      - navigation "Barra de herramientas":
+        - menu:
+          - group [ref=e151]:
+            - menuitem "Acerca de WordPress" [ref=e152] [cursor=pointer]:
+              - generic [ref=e153]: 
+              - generic [ref=e154]: Acerca de WordPress
+          - group [ref=e155]:
+            - menuitem " Guiders WP Test" [ref=e156] [cursor=pointer]
+          - group [ref=e157]:
+            - menuitem "6 actualizaciones disponibles" [ref=e158] [cursor=pointer]:
+              - generic [ref=e159]: 
+              - generic [ref=e160]: "6"
+              - generic [ref=e161]: 6 actualizaciones disponibles
+          - group [ref=e162]:
+            - menuitem "0 comentarios en moderación" [ref=e163] [cursor=pointer]:
+              - generic [ref=e164]: 
+              - generic [ref=e165]: "0"
+              - generic [ref=e166]: 0 comentarios en moderación
+          - group [ref=e167]:
+            - menuitem "Añadir" [ref=e168] [cursor=pointer]:
+              - generic [ref=e169]: 
+              - generic [ref=e170]: Añadir
+        - menu [ref=e171]:
+          - group [ref=e172]:
+            - menuitem "Hola, Roger Puga Ruiz" [ref=e173] [cursor=pointer]
+    - main [ref=e174]:
+      - generic [ref=e175]:
+        - generic [ref=e176]:
+          - text: ¡Ya está disponible
+          - link "WordPress 7.0" [ref=e177] [cursor=pointer]:
+            - /url: https://wordpress.org/documentation/wordpress-version/version-7-0/
+          - text: "!"
+          - link "Por favor, actualiza WordPress ahora" [ref=e178] [cursor=pointer]:
+            - /url: http://localhost:8090/wp-admin/update-core.php
+            - text: Por favor, actualiza ahora
+          - text: .
+        - generic [ref=e179]:
+          - heading "Guiders SDK" [level=1] [ref=e180]
+          - generic [ref=e181]:
+            - heading "Configuración del SDK de Guiders" [level=2] [ref=e182]
+            - paragraph [ref=e183]: Configura el SDK de Guiders para habilitar tracking inteligente, chat en vivo y notificaciones en tu sitio WordPress.
+          - navigation [ref=e184]:
+            - link " General" [ref=e185] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=general"
+              - generic [ref=e186]: 
+              - text: General
+            - link " Chat" [ref=e187] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=chat"
+              - generic [ref=e188]: 
+              - text: Chat
+            - link " Tracking" [ref=e189] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=tracking"
+              - generic [ref=e190]: 
+              - text: Tracking
+            - link " Cookies & GDPR" [ref=e191] [cursor=pointer]:
+              - /url: "?page=guiders-settings&tab=cookies"
+              - generic [ref=e192]: 
+              - text: Cookies & GDPR
+          - generic [ref=e193]:
+            - generic [ref=e195]:
+              - heading "Configuración General" [level=2] [ref=e196]
+              - paragraph [ref=e197]: Configura las opciones básicas del SDK de Guiders.
+              - text: API Key
+              - textbox [ref=e198]: 7a8f08e6b704a17adccd75f1d203a95c9b7d89fff94ad6bfa4de77f3079586ff
+              - paragraph [ref=e199]: Tu API Key de Guiders. Obténla desde tu panel de control de Guiders.
+              - text: Habilitar Guiders SDK
+              - checkbox "Habilitar el SDK de Guiders en tu sitio web" [checked] [ref=e200] [cursor=pointer]
+              - text: Habilitar el SDK de Guiders en tu sitio web Entorno
+              - combobox [ref=e201] [cursor=pointer]:
+                - option "Producción"
+                - option "Desarrollo" [selected]
+              - paragraph [ref=e202]: Selecciona el entorno. Usa "Desarrollo" solo para pruebas locales.
+              - text: Modo de Auto-Init
+              - combobox [ref=e203] [cursor=pointer]:
+                - option "Inmediato (tan pronto cargue el script)"
+                - option "DOM Ready (DOMContentLoaded)" [selected]
+                - option "Delay Personalizado"
+                - option "Manual (lo iniciaré yo)"
+              - paragraph [ref=e204]: "Controla cuándo se inicializa el SDK: inmediato, al estar listo el DOM, con delay o manual."
+              - paragraph [ref=e205]:
+                - button "Guardar Configuración" [ref=e206] [cursor=pointer]
+            - generic [ref=e207]:
+              - generic [ref=e208]:
+                - heading "Configuración Básica" [level=3] [ref=e209]
+                - paragraph [ref=e210]: Comienza configurando tu API Key de Guiders para habilitar todas las funcionalidades del SDK.
+                - list [ref=e211]:
+                  - listitem [ref=e212]:
+                    - text: ⭐
+                    - strong [ref=e213]: "API Key:"
+                    - text: Requerida para todas las funciones
+                  - listitem [ref=e214]:
+                    - text: 🔧
+                    - strong [ref=e215]: "Entorno:"
+                    - text: Usa "production" para sitios en vivo
+                  - listitem [ref=e216]:
+                    - text: ⚡
+                    - strong [ref=e217]: "Auto-Init:"
+                    - text: Controla cuándo se carga el SDK
+              - generic [ref=e218]:
+                - heading "Modos de Auto-Inicialización" [level=3] [ref=e219]
+                - list [ref=e220]:
+                  - listitem [ref=e221]:
+                    - strong [ref=e222]: "immediate:"
+                    - text: Carga instantánea (más rápido)
+                  - listitem [ref=e223]:
+                    - strong [ref=e224]: "domready:"
+                    - text: Espera al DOM (recomendado)
+                  - listitem [ref=e225]:
+                    - strong [ref=e226]: "delayed:"
+                    - text: Retraso personalizado (ms)
+                  - listitem [ref=e227]:
+                    - strong [ref=e228]: "manual:"
+                    - text: Control total via JavaScript
+              - generic [ref=e229]:
+                - heading "Información del Plugin" [level=3] [ref=e230]
+                - paragraph [ref=e231]:
+                  - strong [ref=e232]: "Versión actual:"
+                  - text: v2.13.2
+                - paragraph [ref=e233]: ✅ Plugin actualizado
+                - paragraph [ref=e234]:
+                  - link "🔍 Verificar actualizaciones" [ref=e235] [cursor=pointer]:
+                    - /url: http://localhost:8090/wp-admin/plugins.php?force-check=1
+              - generic [ref=e236]:
+                - heading "Soporte y Documentación" [level=3] [ref=e237]
+                - list [ref=e238]:
+                  - listitem [ref=e239]:
+                    - link "📚 Documentación completa" [ref=e240] [cursor=pointer]:
+                      - /url: https://github.com/RogerPugaRuiz/guiders-sdk
+                  - listitem [ref=e241]:
+                    - link "🌐 Sitio web oficial" [ref=e242] [cursor=pointer]:
+                      - /url: https://guiders.ancoradual.com
+                  - listitem [ref=e243]:
+                    - link "🐛 Reportar problemas" [ref=e244] [cursor=pointer]:
+                      - /url: https://github.com/RogerPugaRuiz/guiders-sdk/issues
+                  - listitem [ref=e245]:
+                    - link "📋 Ver versiones" [ref=e246] [cursor=pointer]:
+                      - /url: https://github.com/RogerPugaRuiz/guiders-sdk/releases
+  - contentinfo [ref=e247]:
+    - paragraph [ref=e248]:
+      - generic [ref=e249]:
+        - text: Gracias por crear con
+        - link "WordPress" [ref=e250] [cursor=pointer]:
+          - /url: https://es.wordpress.org/
+        - text: .
+    - paragraph [ref=e251]:
+      - strong [ref=e252]:
+        - link "Obtener la versión 7.0" [ref=e253] [cursor=pointer]:
+          - /url: http://localhost:8090/wp-admin/update-core.php
+  - text: 

--- a/.playwright-mcp/page-2026-06-11T15-37-24-722Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-37-24-722Z.yml
@@ -1,0 +1,106 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - generic: 🎯 search_submit (90%)

--- a/.playwright-mcp/page-2026-06-11T15-37-42-558Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-37-42-558Z.yml
@@ -1,0 +1,106 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - generic: 🎯 search_submit (90%)

--- a/.playwright-mcp/page-2026-06-11T15-37-53-229Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-37-53-229Z.yml
@@ -1,0 +1,108 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - button "Cambiar los ajustes de cookies" [ref=e101]:
+    - img [ref=e103]
+  - button "Abrir chat" [ref=e107] [cursor=pointer]

--- a/.playwright-mcp/page-2026-06-11T15-38-09-259Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-38-09-259Z.yml
@@ -1,0 +1,106 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - generic: 🎯 search_submit (90%)

--- a/.playwright-mcp/page-2026-06-11T15-38-17-574Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-38-17-574Z.yml
@@ -1,0 +1,108 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - button "Cambiar los ajustes de cookies" [ref=e101]:
+    - img [ref=e103]
+  - button "Abrir chat" [ref=e107] [cursor=pointer]

--- a/.playwright-mcp/page-2026-06-11T15-39-20-303Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-39-20-303Z.yml
@@ -1,0 +1,106 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - generic: 🎯 search_submit (90%)

--- a/.playwright-mcp/page-2026-06-11T15-39-28-061Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-39-28-061Z.yml
@@ -1,0 +1,108 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - button "Cambiar los ajustes de cookies" [ref=e101]:
+    - img [ref=e103]
+  - button "Abrir chat" [ref=e107] [cursor=pointer]

--- a/.playwright-mcp/page-2026-06-11T15-40-03-647Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-40-03-647Z.yml
@@ -1,0 +1,106 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - generic: 🎯 search_submit (90%)

--- a/.playwright-mcp/page-2026-06-11T15-40-18-861Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-40-18-861Z.yml
@@ -1,0 +1,108 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - navigation "Barra de herramientas":
+      - menu:
+        - group [ref=e3]:
+          - menuitem "Acerca de WordPress" [ref=e4] [cursor=pointer]:
+            - generic [ref=e5]: 
+            - generic [ref=e6]: Acerca de WordPress
+        - group [ref=e7]:
+          - menuitem " Guiders WP Test" [ref=e8] [cursor=pointer]
+        - group [ref=e9]:
+          - menuitem " Editar el sitio" [ref=e10] [cursor=pointer]
+        - group [ref=e11]:
+          - menuitem "5 actualizaciones disponibles" [ref=e12] [cursor=pointer]:
+            - generic [ref=e13]: 
+            - generic [ref=e14]: "5"
+            - generic [ref=e15]: 5 actualizaciones disponibles
+        - group [ref=e16]:
+          - menuitem "0 comentarios en moderación" [ref=e17] [cursor=pointer]:
+            - generic [ref=e18]: 
+            - generic [ref=e19]: "0"
+            - generic [ref=e20]: 0 comentarios en moderación
+        - group [ref=e21]:
+          - menuitem "Añadir" [ref=e22] [cursor=pointer]:
+            - generic [ref=e23]: 
+            - generic [ref=e24]: Añadir
+      - menu [ref=e25]:
+        - group [ref=e26]:
+          - menuitem "Hola, Roger Puga Ruiz" [ref=e27] [cursor=pointer]
+        - group [ref=e28]:
+          - menuitem " Buscar" [ref=e29]:
+            - generic [ref=e30]:
+              - text: 
+              - textbox "Buscar" [ref=e31] [cursor=pointer]
+              - generic [ref=e32]: Buscar
+  - link "Saltar al contenido" [ref=e33] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e34]:
+    - banner [ref=e35]:
+      - generic [ref=e38]:
+        - paragraph [ref=e39]:
+          - link "Guiders WP Test" [ref=e40] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e42]:
+          - list [ref=e47]:
+            - list [ref=e48]:
+              - listitem [ref=e49]:
+                - link "Página de ejemplo" [ref=e50] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e51]:
+                - link "Precios" [ref=e52] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e53]:
+      - heading "Blog" [level=1] [ref=e54]
+      - list [ref=e56]:
+        - listitem [ref=e57]:
+          - generic [ref=e58]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e59]:
+              - link "¡Hola, mundo!" [ref=e60] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e62]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e64]:
+              - link "25 de noviembre de 2025" [ref=e65] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e67]:
+      - generic [ref=e69]:
+        - generic [ref=e70]:
+          - heading "Guiders WP Test" [level=2] [ref=e73]:
+            - link "Guiders WP Test" [ref=e74] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e75]:
+            - navigation [ref=e76]:
+              - list [ref=e77]:
+                - listitem [ref=e78]:
+                  - link "Blog" [ref=e79] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e80]:
+                  - link "Acerca de" [ref=e81] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e82]:
+                  - link "FAQs" [ref=e83] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e84]:
+                  - link "Autores" [ref=e85] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e86]:
+              - list [ref=e87]:
+                - listitem [ref=e88]:
+                  - link "Eventos" [ref=e89] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e90]:
+                  - link "Tienda" [ref=e91] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e92]:
+                  - link "Patrones" [ref=e93] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e94]:
+                  - link "Temas" [ref=e95] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e97]:
+          - paragraph [ref=e98]: Twenty Twenty-Five
+          - paragraph [ref=e99]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e100] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - button "Cambiar los ajustes de cookies" [ref=e101]:
+    - img [ref=e103]
+  - button "Abrir chat" [ref=e107] [cursor=pointer]

--- a/.playwright-mcp/page-2026-06-11T15-54-16-843Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-54-16-843Z.yml
@@ -1,0 +1,71 @@
+- generic [active] [ref=e1]:
+  - link "Saltar al contenido" [ref=e2] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e3]:
+    - banner [ref=e4]:
+      - generic [ref=e7]:
+        - paragraph [ref=e8]:
+          - link "Guiders WP Test" [ref=e9] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e11]:
+          - list [ref=e16]:
+            - list [ref=e17]:
+              - listitem [ref=e18]:
+                - link "Página de ejemplo" [ref=e19] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e20]:
+                - link "Precios" [ref=e21] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e22]:
+      - heading "Blog" [level=1] [ref=e23]
+      - list [ref=e25]:
+        - listitem [ref=e26]:
+          - generic [ref=e27]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e28]:
+              - link "¡Hola, mundo!" [ref=e29] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e31]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e33]:
+              - link "25 de noviembre de 2025" [ref=e34] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e36]:
+      - generic [ref=e38]:
+        - generic [ref=e39]:
+          - heading "Guiders WP Test" [level=2] [ref=e42]:
+            - link "Guiders WP Test" [ref=e43] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e44]:
+            - navigation [ref=e45]:
+              - list [ref=e46]:
+                - listitem [ref=e47]:
+                  - link "Blog" [ref=e48] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e49]:
+                  - link "Acerca de" [ref=e50] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e51]:
+                  - link "FAQs" [ref=e52] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e53]:
+                  - link "Autores" [ref=e54] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e55]:
+              - list [ref=e56]:
+                - listitem [ref=e57]:
+                  - link "Eventos" [ref=e58] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e59]:
+                  - link "Tienda" [ref=e60] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e61]:
+                  - link "Patrones" [ref=e62] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e63]:
+                  - link "Temas" [ref=e64] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e66]:
+          - paragraph [ref=e67]: Twenty Twenty-Five
+          - paragraph [ref=e68]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e69] [cursor=pointer]:
+              - /url: https://es.wordpress.org

--- a/.playwright-mcp/page-2026-06-11T15-54-25-299Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-54-25-299Z.yml
@@ -1,0 +1,74 @@
+- generic [active] [ref=e1]:
+  - link "Saltar al contenido" [ref=e2] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e3]:
+    - banner [ref=e4]:
+      - generic [ref=e7]:
+        - paragraph [ref=e8]:
+          - link "Guiders WP Test" [ref=e9] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e11]:
+          - list [ref=e16]:
+            - list [ref=e17]:
+              - listitem [ref=e18]:
+                - link "Página de ejemplo" [ref=e19] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e20]:
+                - link "Precios" [ref=e21] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e22]:
+      - heading "Blog" [level=1] [ref=e23]
+      - list [ref=e25]:
+        - listitem [ref=e26]:
+          - generic [ref=e27]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e28]:
+              - link "¡Hola, mundo!" [ref=e29] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e31]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e33]:
+              - link "25 de noviembre de 2025" [ref=e34] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e36]:
+      - generic [ref=e38]:
+        - generic [ref=e39]:
+          - heading "Guiders WP Test" [level=2] [ref=e42]:
+            - link "Guiders WP Test" [ref=e43] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e44]:
+            - navigation [ref=e45]:
+              - list [ref=e46]:
+                - listitem [ref=e47]:
+                  - link "Blog" [ref=e48] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e49]:
+                  - link "Acerca de" [ref=e50] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e51]:
+                  - link "FAQs" [ref=e52] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e53]:
+                  - link "Autores" [ref=e54] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e55]:
+              - list [ref=e56]:
+                - listitem [ref=e57]:
+                  - link "Eventos" [ref=e58] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e59]:
+                  - link "Tienda" [ref=e60] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e61]:
+                  - link "Patrones" [ref=e62] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e63]:
+                  - link "Temas" [ref=e64] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e66]:
+          - paragraph [ref=e67]: Twenty Twenty-Five
+          - paragraph [ref=e68]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e69] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - button "Cambiar los ajustes de cookies" [ref=e70]:
+    - img [ref=e72]
+  - button "Abrir chat" [ref=e76] [cursor=pointer]

--- a/.playwright-mcp/page-2026-06-11T15-56-54-657Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-56-54-657Z.yml
@@ -1,0 +1,71 @@
+- generic [active] [ref=e1]:
+  - link "Saltar al contenido" [ref=e2] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e3]:
+    - banner [ref=e4]:
+      - generic [ref=e7]:
+        - paragraph [ref=e8]:
+          - link "Guiders WP Test" [ref=e9] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e11]:
+          - list [ref=e16]:
+            - list [ref=e17]:
+              - listitem [ref=e18]:
+                - link "Página de ejemplo" [ref=e19] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e20]:
+                - link "Precios" [ref=e21] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e22]:
+      - heading "Blog" [level=1] [ref=e23]
+      - list [ref=e25]:
+        - listitem [ref=e26]:
+          - generic [ref=e27]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e28]:
+              - link "¡Hola, mundo!" [ref=e29] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e31]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e33]:
+              - link "25 de noviembre de 2025" [ref=e34] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e36]:
+      - generic [ref=e38]:
+        - generic [ref=e39]:
+          - heading "Guiders WP Test" [level=2] [ref=e42]:
+            - link "Guiders WP Test" [ref=e43] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e44]:
+            - navigation [ref=e45]:
+              - list [ref=e46]:
+                - listitem [ref=e47]:
+                  - link "Blog" [ref=e48] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e49]:
+                  - link "Acerca de" [ref=e50] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e51]:
+                  - link "FAQs" [ref=e52] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e53]:
+                  - link "Autores" [ref=e54] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e55]:
+              - list [ref=e56]:
+                - listitem [ref=e57]:
+                  - link "Eventos" [ref=e58] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e59]:
+                  - link "Tienda" [ref=e60] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e61]:
+                  - link "Patrones" [ref=e62] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e63]:
+                  - link "Temas" [ref=e64] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e66]:
+          - paragraph [ref=e67]: Twenty Twenty-Five
+          - paragraph [ref=e68]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e69] [cursor=pointer]:
+              - /url: https://es.wordpress.org

--- a/.playwright-mcp/page-2026-06-11T15-57-02-967Z.yml
+++ b/.playwright-mcp/page-2026-06-11T15-57-02-967Z.yml
@@ -1,0 +1,74 @@
+- generic [active] [ref=e1]:
+  - link "Saltar al contenido" [ref=e2] [cursor=pointer]:
+    - /url: "#wp--skip-link--target"
+  - generic [ref=e3]:
+    - banner [ref=e4]:
+      - generic [ref=e7]:
+        - paragraph [ref=e8]:
+          - link "Guiders WP Test" [ref=e9] [cursor=pointer]:
+            - /url: http://localhost:8090
+        - navigation [ref=e11]:
+          - list [ref=e16]:
+            - list [ref=e17]:
+              - listitem [ref=e18]:
+                - link "Página de ejemplo" [ref=e19] [cursor=pointer]:
+                  - /url: http://localhost:8090/pagina-ejemplo/
+              - listitem [ref=e20]:
+                - link "Precios" [ref=e21] [cursor=pointer]:
+                  - /url: http://localhost:8090/precios/
+    - main [ref=e22]:
+      - heading "Blog" [level=1] [ref=e23]
+      - list [ref=e25]:
+        - listitem [ref=e26]:
+          - generic [ref=e27]:
+            - heading "¡Hola, mundo!" [level=2] [ref=e28]:
+              - link "¡Hola, mundo!" [ref=e29] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+            - paragraph [ref=e31]: Te damos la bienvenida a WordPress. Esta es tu primera entrada. Edítala o bórrala, ¡luego empieza a escribir!
+            - time [ref=e33]:
+              - link "25 de noviembre de 2025" [ref=e34] [cursor=pointer]:
+                - /url: http://localhost:8090/hola-mundo/
+    - contentinfo [ref=e36]:
+      - generic [ref=e38]:
+        - generic [ref=e39]:
+          - heading "Guiders WP Test" [level=2] [ref=e42]:
+            - link "Guiders WP Test" [ref=e43] [cursor=pointer]:
+              - /url: http://localhost:8090
+          - generic [ref=e44]:
+            - navigation [ref=e45]:
+              - list [ref=e46]:
+                - listitem [ref=e47]:
+                  - link "Blog" [ref=e48] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e49]:
+                  - link "Acerca de" [ref=e50] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e51]:
+                  - link "FAQs" [ref=e52] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e53]:
+                  - link "Autores" [ref=e54] [cursor=pointer]:
+                    - /url: "#"
+            - navigation [ref=e55]:
+              - list [ref=e56]:
+                - listitem [ref=e57]:
+                  - link "Eventos" [ref=e58] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e59]:
+                  - link "Tienda" [ref=e60] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e61]:
+                  - link "Patrones" [ref=e62] [cursor=pointer]:
+                    - /url: "#"
+                - listitem [ref=e63]:
+                  - link "Temas" [ref=e64] [cursor=pointer]:
+                    - /url: "#"
+        - generic [ref=e66]:
+          - paragraph [ref=e67]: Twenty Twenty-Five
+          - paragraph [ref=e68]:
+            - text: Diseñado con
+            - link "WordPress" [ref=e69] [cursor=pointer]:
+              - /url: https://es.wordpress.org
+  - button "Cambiar los ajustes de cookies" [ref=e70]:
+    - img [ref=e72]
+  - button "Abrir chat" [ref=e76] [cursor=pointer]

--- a/opencode.json
+++ b/opencode.json
@@ -2,7 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "agent": {
     "explore": {
-      "model": "github-copilot/claude-haiku-4.5"
+      "model": "minimax-coding-plan/MiniMax-M2.7"
     }
   },
   "mcp": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -293,15 +293,16 @@ export class AppModule {
     // Configuración estándar de NestJS Mongoose según la documentación oficial
     const mongooseOptions = {
       uri,
-      // Configuraciones estándar recomendadas
+      // Configuraciones de producción
       serverSelectionTimeoutMS: 10000,
       socketTimeoutMS: 45000,
       connectTimeoutMS: 10000,
-      maxPoolSize: 10,
-      minPoolSize: 5,
+      maxPoolSize: 100,
+      minPoolSize: 10,
       maxIdleTimeMS: 30000,
       retryWrites: true,
       retryReads: true,
+      directConnection: false,
     };
 
     logger.log('MongoDB Options Object:');

--- a/src/context/auth/api-key/domain/model/api-key-domain.ts
+++ b/src/context/auth/api-key/domain/model/api-key-domain.ts
@@ -5,9 +5,9 @@ export class ApiKeyDomain extends PrimitiveValueObject<string> {
     super(
       value,
       (value: string) => {
-        // La validación permite dominios que contengan letras, números, guiones, puntos y guión bajo
+        // La validación permite dominios que contengan letras, números, guiones, puntos, guión bajo y puertos (e.g., localhost:8080)
         // Los dominios con www. son válidos y se normalizan en los casos de uso
-        const regex = /^[a-zA-Z0-9._-]+$/;
+        const regex = /^[a-zA-Z0-9._:-]+$/;
         return regex.test(value);
       },
       'Invalid API key domain format',

--- a/src/context/company/company.module.ts
+++ b/src/context/company/company.module.ts
@@ -6,6 +6,7 @@ import { ConfigModule } from '@nestjs/config';
 import { SEARCH_PROVIDER } from 'src/context/shared/domain/search';
 import { CompanySearchProvider } from './infrastructure/search/company-search.provider';
 import { CompanyTypeOrmEntity } from './infrastructure/persistence/entity/company-typeorm.entity';
+import { CompanySiteTypeOrmEntity } from './infrastructure/persistence/typeorm/company-site.entity';
 import { companyRepositoryProvider } from './infrastructure/persistence/impl/company.repository.impl';
 import { CreateCompanyCommandHandler } from './application/commands/create-company-command.handler';
 import { CreateCompanyWithAdminCommandHandler } from './application/commands/create-company-with-admin-command.handler';
@@ -20,7 +21,7 @@ import { BffSessionAuthService } from '../shared/infrastructure/services/bff-ses
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([CompanyTypeOrmEntity]),
+    TypeOrmModule.forFeature([CompanyTypeOrmEntity, CompanySiteTypeOrmEntity]),
     CqrsModule,
     HttpModule,
     JwtModule.register({}),

--- a/src/context/company/domain/value-objects/canonical-domain.ts
+++ b/src/context/company/domain/value-objects/canonical-domain.ts
@@ -5,7 +5,9 @@ import { PrimitiveValueObject } from 'src/context/shared/domain/primitive-value-
 const validateCanonicalDomain = (value: string) =>
   typeof value === 'string' &&
   value.trim().length > 0 &&
-  (value === 'localhost' || value.includes('.')) &&
+  (value === 'localhost' ||
+    /^localhost:\d+$/.test(value) ||
+    value.includes('.')) &&
   value.length <= 255;
 
 export class CanonicalDomain extends PrimitiveValueObject<string> {

--- a/src/context/company/infrastructure/persistence/impl/company.mapper.ts
+++ b/src/context/company/infrastructure/persistence/impl/company.mapper.ts
@@ -18,19 +18,35 @@ export class CompanyMapper {
     if (entity.sites && entity.sites.length > 0) {
       // Agrupar sites por dominio canónico
       const canonicalSites = entity.sites.filter((site) => site.isCanonical);
+      const nonCanonicalSites = entity.sites.filter(
+        (site) => !site.isCanonical,
+      );
 
-      canonicalSites.forEach((canonicalSite, index) => {
-        const aliases = entity.sites
-          .filter((site) => !site.isCanonical)
-          .map((site) => site.domain);
+      if (canonicalSites.length > 0) {
+        // Hay sitios canónicos - agrupar aliases correctamente
+        canonicalSites.forEach((canonicalSite, index) => {
+          // Los aliases son todos los sitios no-canónicos de esta empresa
+          const aliases = nonCanonicalSites.map((site) => site.domain);
+
+          sites.push({
+            id: canonicalSite.id,
+            name: `Sitio ${index + 1}`,
+            canonicalDomain: canonicalSite.domain,
+            domainAliases: aliases,
+          });
+        });
+      } else if (nonCanonicalSites.length > 0) {
+        // No hay sitios canónicos - usar el primer no-canónico como canónico
+        const firstNonCanonical = nonCanonicalSites[0];
+        const aliases = nonCanonicalSites.slice(1).map((site) => site.domain);
 
         sites.push({
-          id: canonicalSite.id, // Usar el ID real del sitio desde la DB
-          name: `Sitio ${index + 1}`,
-          canonicalDomain: canonicalSite.domain,
+          id: firstNonCanonical.id,
+          name: 'Sitio 1',
+          canonicalDomain: firstNonCanonical.domain,
           domainAliases: aliases,
         });
-      });
+      }
     }
 
     return Company.fromPrimitives({

--- a/src/context/company/infrastructure/persistence/impl/company.repository.impl.ts
+++ b/src/context/company/infrastructure/persistence/impl/company.repository.impl.ts
@@ -184,7 +184,6 @@ export class CompanyRepositoryTypeOrmImpl implements CompanyRepository {
   // Busca una empresa por dominio
   async findByDomain(domain: string): Promise<Result<Company, DomainError>> {
     try {
-      // Busca una empresa que tenga el dominio en sus sites
       const entity = await this.companyRepo
         .createQueryBuilder('companies')
         .leftJoinAndSelect('companies.sites', 'sites')

--- a/src/context/conversations-v2/application/commands/reset-chat-unread-count.command-handler.ts
+++ b/src/context/conversations-v2/application/commands/reset-chat-unread-count.command-handler.ts
@@ -91,7 +91,12 @@ export class ResetChatUnreadCountCommandHandler
 
     // Notificar via WebSocket que el contador es 0
     this.eventBus.publish(
-      new UnreadCountUpdatedEvent({ chatId: command.chatId, newCount: 0 }),
+      new UnreadCountUpdatedEvent({
+        chatId: command.chatId,
+        visitorId: chat.visitorId.getValue(),
+        companyId: chat.companyId,
+        newCount: 0,
+      }),
     );
 
     return ok(undefined);

--- a/src/context/conversations-v2/application/events/__tests__/notify-chat-created-on-chat-created.event-handler.spec.ts
+++ b/src/context/conversations-v2/application/events/__tests__/notify-chat-created-on-chat-created.event-handler.spec.ts
@@ -34,7 +34,7 @@ describe('NotifyChatCreatedOnChatCreatedEventHandler', () => {
   });
 
   describe('handle', () => {
-    it('debe emitir notificación de chat creado a la sala del visitante', () => {
+    it('debe emitir notificación de chat creado a la sala del visitante y del tenant', () => {
       // Arrange
       const event = new ChatCreatedEvent({
         chat: {
@@ -55,7 +55,8 @@ describe('NotifyChatCreatedOnChatCreatedEventHandler', () => {
       handler.handle(event);
 
       // Assert
-      expect(mockGateway.emitToRoom).toHaveBeenCalledTimes(1);
+      // Se emite a la sala del visitante y a la sala del tenant
+      expect(mockGateway.emitToRoom).toHaveBeenCalledTimes(2);
       expect(mockGateway.emitToRoom).toHaveBeenCalledWith(
         'visitor:visitor-456',
         'chat:created',
@@ -70,6 +71,16 @@ describe('NotifyChatCreatedOnChatCreatedEventHandler', () => {
           },
           createdAt: '2025-10-13T10:00:00.000Z',
           message: 'Un comercial ha iniciado una conversación contigo',
+        }),
+      );
+      expect(mockGateway.emitToRoom).toHaveBeenCalledWith(
+        'tenant:company-789',
+        'chat:created',
+        expect.objectContaining({
+          chatId: 'chat-123',
+          visitorId: 'visitor-456',
+          status: 'PENDING',
+          priority: 'NORMAL',
         }),
       );
     });

--- a/src/context/conversations-v2/application/events/notify-chat-created-on-chat-created.event-handler.ts
+++ b/src/context/conversations-v2/application/events/notify-chat-created-on-chat-created.event-handler.ts
@@ -42,6 +42,7 @@ export class NotifyChatCreatedOnChatCreatedEventHandler
     try {
       const chatData = event.getChatData();
       const visitorId = event.getVisitorId();
+      const companyId = event.getCompanyId();
 
       this.logger.log(
         `📍 Datos del evento: chatId=${chatData.chatId}, visitorId=${visitorId}, status=${chatData.status}`,
@@ -69,6 +70,19 @@ export class NotifyChatCreatedOnChatCreatedEventHandler
 
       // Emitir a la sala del visitante
       this.websocketGateway.emitToRoom(roomName, 'chat:created', payload);
+
+      // Emitir también al room del tenant para que la lista de visitantes
+      // se actualice en tiempo real cuando se crea un nuevo chat
+      if (companyId) {
+        this.websocketGateway.emitToRoom(
+          `tenant:${companyId}`,
+          'chat:created',
+          payload,
+        );
+        this.logger.log(
+          `📢 Notificado tenant ${companyId} de nuevo chat ${chatData.chatId} para visitante ${visitorId}`,
+        );
+      }
 
       this.logger.log(
         `✅ Notificación de chat creado enviada exitosamente al visitante ${visitorId}`,

--- a/src/context/conversations-v2/application/events/notify-unread-count-updated-on-unread-count-updated.event-handler.ts
+++ b/src/context/conversations-v2/application/events/notify-unread-count-updated-on-unread-count-updated.event-handler.ts
@@ -36,13 +36,15 @@ export class NotifyUnreadCountUpdatedOnUnreadCountUpdatedEventHandler
   handle(event: UnreadCountUpdatedEvent): void {
     const chatId = event.getChatId();
     const newCount = event.getNewCount();
+    const visitorId = event.getVisitorId();
+    const companyId = event.getCompanyId();
 
     this.logger.log(
       `Notificando unreadMessagesCount actualizado para chat ${chatId}: ${newCount}`,
     );
 
     try {
-      // Notificar solo a la sala de comerciales — los visitantes no necesitan el badge
+      // Notificar a la sala de comerciales del chat (sidebar del inbox / vista de chat)
       this.websocketGateway.emitToRoom(
         `chat:${chatId}:commercial`,
         'chat:unread_count',
@@ -51,6 +53,20 @@ export class NotifyUnreadCountUpdatedOnUnreadCountUpdatedEventHandler
           unreadMessagesCount: newCount,
         },
       );
+
+      // Notificar también al room del tenant para que la lista de visitantes
+      // actualice el badge del visitante asociado al chat en tiempo real
+      if (companyId) {
+        this.websocketGateway.emitToRoom(
+          `tenant:${companyId}`,
+          'chat:unread_count',
+          {
+            chatId,
+            visitorId,
+            unreadMessagesCount: newCount,
+          },
+        );
+      }
     } catch (error) {
       const errorObj = error as Error;
       this.logger.error(

--- a/src/context/conversations-v2/application/events/update-chat-on-message-sent.event-handler.ts
+++ b/src/context/conversations-v2/application/events/update-chat-on-message-sent.event-handler.ts
@@ -122,7 +122,12 @@ export class UpdateChatOnMessageSentEventHandler
         // Esto permite que el handler de notificaciones WS use el valor real
         // sin necesidad de hacer una query adicional (elimina la race condition).
         this.eventBus.publish(
-          new UnreadCountUpdatedEvent({ chatId, newCount }),
+          new UnreadCountUpdatedEvent({
+            chatId,
+            visitorId: chat.visitorId.getValue(),
+            companyId: chat.companyId,
+            newCount,
+          }),
         );
       }
 

--- a/src/context/conversations-v2/domain/events/unread-count-updated.event.ts
+++ b/src/context/conversations-v2/domain/events/unread-count-updated.event.ts
@@ -9,9 +9,16 @@ import { DomainEvent } from 'src/context/shared/domain/domain-event';
  */
 export class UnreadCountUpdatedEvent extends DomainEvent<{
   chatId: string;
+  visitorId: string;
+  companyId: string;
   newCount: number;
 }> {
-  constructor(data: { chatId: string; newCount: number }) {
+  constructor(data: {
+    chatId: string;
+    visitorId: string;
+    companyId: string;
+    newCount: number;
+  }) {
     super(data);
   }
 
@@ -19,6 +26,14 @@ export class UnreadCountUpdatedEvent extends DomainEvent<{
 
   getChatId(): string {
     return this.attributes.chatId;
+  }
+
+  getVisitorId(): string {
+    return this.attributes.visitorId;
+  }
+
+  getCompanyId(): string {
+    return this.attributes.companyId;
   }
 
   getNewCount(): number {

--- a/src/context/visitors-v2/application/dtos/visitor-stats-response.dto.ts
+++ b/src/context/visitors-v2/application/dtos/visitor-stats-response.dto.ts
@@ -1,0 +1,55 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TopPageDto {
+  @ApiProperty({ description: 'URL de la página' })
+  url: string;
+
+  @ApiProperty({ description: 'Título de la página', required: false })
+  title?: string;
+
+  @ApiProperty({ description: 'Número de visitas' })
+  views: number;
+}
+
+export class TopSourceDto {
+  @ApiProperty({ description: 'Fuente del visitante' })
+  source: string;
+
+  @ApiProperty({ description: 'Número de visitantes' })
+  visitors: number;
+}
+
+export class VisitorStatsResponseDto {
+  @ApiProperty({ description: 'Total de visitantes' })
+  totalVisitors: number;
+
+  @ApiProperty({ description: 'Visitantes en línea actualmente' })
+  onlineVisitors: number;
+
+  @ApiProperty({ description: 'Visitantes nuevos' })
+  newVisitors: number;
+
+  @ApiProperty({ description: 'Visitantes que regresan' })
+  returningVisitors: number;
+
+  @ApiProperty({ description: 'Visitantes con chats pendientes' })
+  withPendingChats: number;
+
+  @ApiProperty({ description: 'Duración promedio de sesión en segundos' })
+  averageSessionDuration: number;
+
+  @ApiProperty({ description: 'Tasa de rebote (0-100)' })
+  bounceRate: number;
+
+  @ApiProperty({ description: 'Tasa de conversión (0-100)' })
+  conversionRate: number;
+
+  @ApiProperty({ description: 'Páginas más visitadas', type: [TopPageDto] })
+  topPages: TopPageDto[];
+
+  @ApiProperty({
+    description: 'Principales fuentes de tráfico',
+    type: [TopSourceDto],
+  })
+  topSources: TopSourceDto[];
+}

--- a/src/context/visitors-v2/application/queries/get-visitor-stats.query-handler.ts
+++ b/src/context/visitors-v2/application/queries/get-visitor-stats.query-handler.ts
@@ -1,0 +1,212 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { Inject, Logger } from '@nestjs/common';
+import { GetVisitorStatsQuery } from './get-visitor-stats.query';
+import {
+  VisitorStatsResponseDto,
+  TopPageDto,
+  TopSourceDto,
+} from '../dtos/visitor-stats-response.dto';
+import {
+  VISITOR_V2_REPOSITORY,
+  VisitorV2Repository,
+} from '../../domain/visitor-v2.repository';
+import { TenantId } from '../../domain/value-objects/tenant-id';
+import {
+  CHAT_V2_REPOSITORY,
+  IChatRepository,
+} from '../../../conversations-v2/domain/chat.repository';
+import {
+  VisitorConnectionDomainService,
+  VISITOR_CONNECTION_DOMAIN_SERVICE,
+} from '../../domain/visitor-connection.domain-service';
+import { ConnectionStatus } from '../../domain/value-objects/visitor-connection';
+import { VisitorLifecycle } from '../../domain/value-objects/visitor-lifecycle';
+
+@QueryHandler(GetVisitorStatsQuery)
+export class GetVisitorStatsQueryHandler
+  implements IQueryHandler<GetVisitorStatsQuery, VisitorStatsResponseDto>
+{
+  private readonly logger = new Logger(GetVisitorStatsQueryHandler.name);
+
+  constructor(
+    @Inject(VISITOR_V2_REPOSITORY)
+    private readonly visitorRepository: VisitorV2Repository,
+    @Inject(CHAT_V2_REPOSITORY)
+    private readonly chatRepository: IChatRepository,
+    @Inject(VISITOR_CONNECTION_DOMAIN_SERVICE)
+    private readonly connectionService: VisitorConnectionDomainService,
+  ) {}
+
+  async execute(query: GetVisitorStatsQuery): Promise<VisitorStatsResponseDto> {
+    this.logger.log(`Obteniendo estadísticas para tenant: ${query.tenantId}`);
+
+    try {
+      const tenantId = new TenantId(query.tenantId);
+
+      const visitorsResult =
+        await this.visitorRepository.findByTenantId(tenantId);
+
+      if (visitorsResult.isErr()) {
+        this.logger.error(
+          `Error al obtener visitantes: ${visitorsResult.error.message}`,
+        );
+        throw new Error(visitorsResult.error.message);
+      }
+
+      const visitors = visitorsResult.value;
+      const totalVisitors = visitors.length;
+
+      let onlineVisitors = 0;
+      for (const visitor of visitors) {
+        try {
+          const status = await this.connectionService.getConnectionStatus(
+            visitor.getId(),
+          );
+          if (status.isOnline()) {
+            onlineVisitors++;
+          }
+        } catch {
+          const activeSessions = visitor
+            .getSessions()
+            .filter((s) => s.isActive());
+          if (activeSessions.length > 0) {
+            onlineVisitors++;
+          }
+        }
+      }
+
+      let newVisitors = 0;
+      let returningVisitors = 0;
+      let withPendingChats = 0;
+      let totalSessionDuration = 0;
+      let totalSessions = 0;
+
+      for (const visitor of visitors) {
+        const sessions = visitor.getSessions();
+        const sessionCount = sessions.length;
+
+        if (sessionCount <= 1) {
+          newVisitors++;
+        } else {
+          returningVisitors++;
+        }
+
+        for (const session of sessions) {
+          totalSessionDuration += session.getDuration();
+          totalSessions++;
+        }
+
+        try {
+          const pendingChats = await this.chatRepository.getPendingQueue(
+            undefined,
+            100,
+          );
+          if (pendingChats.isOk()) {
+            const visitorId = visitor.getId().getValue();
+            const hasPending = pendingChats.value.some(
+              (chat) => chat.visitorId.getValue() === visitorId,
+            );
+            if (hasPending) {
+              withPendingChats++;
+            }
+          }
+        } catch {
+          // Ignore
+        }
+      }
+
+      const averageSessionDuration =
+        totalSessions > 0
+          ? Math.round(totalSessionDuration / totalSessions / 1000)
+          : 0;
+
+      const bouncedVisitors = visitors.filter((v) => {
+        const sessions = v.getSessions();
+        return sessions.length === 1 && sessions[0].getDuration() < 10000;
+      }).length;
+      const bounceRate =
+        totalVisitors > 0
+          ? Math.round((bouncedVisitors / totalVisitors) * 100)
+          : 0;
+
+      const convertedVisitors = visitors.filter((v) => {
+        const lifecycle = v.getLifecycle().getValue();
+        return (
+          lifecycle === VisitorLifecycle.LEAD ||
+          lifecycle === VisitorLifecycle.CONVERTED
+        );
+      }).length;
+      const conversionRate =
+        totalVisitors > 0
+          ? Math.round((convertedVisitors / totalVisitors) * 100)
+          : 0;
+
+      const pageCounts = new Map<string, { title?: string; views: number }>();
+      for (const visitor of visitors) {
+        for (const session of visitor.getSessions()) {
+          const url = session.getCurrentUrl();
+          if (url) {
+            const existing = pageCounts.get(url);
+            if (existing) {
+              existing.views++;
+            } else {
+              pageCounts.set(url, { views: 1 });
+            }
+          }
+        }
+      }
+      const topPages: TopPageDto[] = Array.from(pageCounts.entries())
+        .sort((a, b) => b[1].views - a[1].views)
+        .slice(0, 10)
+        .map(([url, data]) => ({
+          url,
+          title: data.title,
+          views: data.views,
+        }));
+
+      const sourceCounts = new Map<string, number>();
+      for (const visitor of visitors) {
+        for (const session of visitor.getSessions()) {
+          const ip = session['ipAddress'];
+          const source = ip ? `IP:${ip.substring(0, 6)}...` : 'direct';
+          const existing = sourceCounts.get(source);
+          if (existing !== undefined) {
+            sourceCounts.set(source, existing + 1);
+          } else {
+            sourceCounts.set(source, 1);
+          }
+        }
+      }
+      const topSources: TopSourceDto[] = Array.from(sourceCounts.entries())
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([source, count]) => ({
+          source,
+          visitors: count,
+        }));
+
+      this.logger.log(
+        `Estadísticas calculadas para tenant ${query.tenantId}: ${totalVisitors} visitantes, ${onlineVisitors} online`,
+      );
+
+      return {
+        totalVisitors,
+        onlineVisitors,
+        newVisitors,
+        returningVisitors,
+        withPendingChats,
+        averageSessionDuration,
+        bounceRate,
+        conversionRate,
+        topPages,
+        topSources,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Error en GetVisitorStatsQueryHandler: ${(error as Error).message}`,
+        (error as Error).stack,
+      );
+      throw error;
+    }
+  }
+}

--- a/src/context/visitors-v2/application/queries/get-visitor-stats.query-handler.ts
+++ b/src/context/visitors-v2/application/queries/get-visitor-stats.query-handler.ts
@@ -19,7 +19,6 @@ import {
   VisitorConnectionDomainService,
   VISITOR_CONNECTION_DOMAIN_SERVICE,
 } from '../../domain/visitor-connection.domain-service';
-import { ConnectionStatus } from '../../domain/value-objects/visitor-connection';
 import { VisitorLifecycle } from '../../domain/value-objects/visitor-lifecycle';
 
 @QueryHandler(GetVisitorStatsQuery)

--- a/src/context/visitors-v2/application/queries/get-visitor-stats.query.ts
+++ b/src/context/visitors-v2/application/queries/get-visitor-stats.query.ts
@@ -1,0 +1,7 @@
+export class GetVisitorStatsQuery {
+  constructor(public readonly tenantId: string) {}
+
+  static create(props: { tenantId: string }): GetVisitorStatsQuery {
+    return new GetVisitorStatsQuery(props.tenantId);
+  }
+}

--- a/src/context/visitors-v2/infrastructure/controllers/tenant-visitors.controller.ts
+++ b/src/context/visitors-v2/infrastructure/controllers/tenant-visitors.controller.ts
@@ -60,6 +60,8 @@ import { Result } from 'src/context/shared/domain/result';
 import { DomainError } from 'src/context/shared/domain/domain.error';
 import { SearchVisitorsResponseDto } from '../../application/dtos/visitor-search-response.dto';
 import { QuickFiltersConfigResponseDto } from '../../application/dtos/quick-filters.dto';
+import { GetVisitorStatsQuery } from '../../application/queries/get-visitor-stats.query';
+import { VisitorStatsResponseDto } from '../../application/dtos/visitor-stats-response.dto';
 import {
   CreateSavedFilterDto,
   SavedFiltersListResponseDto,
@@ -203,6 +205,35 @@ export class TenantVisitorsController {
       offset: queryParams.offset,
     });
 
+    return await this.queryBus.execute(query);
+  }
+
+  @Get(':tenantId/visitors/stats')
+  @Roles(['commercial', 'admin'])
+  @ApiOperation({
+    summary: 'Obtener estadísticas de visitantes del tenant',
+    description:
+      'Retorna estadísticas aggregate de visitantes incluyendo total, online, nuevos, returning, chats pendientes, duración promedio de sesión, tasas de rebote y conversión, páginas más visitadas y fuentes de tráfico.',
+  })
+  @ApiParam({
+    name: 'tenantId',
+    description: 'ID único del tenant (empresa)',
+    example: 'tenant-uuid-123',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Estadísticas de visitantes obtenidas exitosamente',
+    type: VisitorStatsResponseDto,
+  })
+  @ApiValidationError('ID de tenant inválido')
+  async getVisitorStats(
+    @Param('tenantId', ParseUUIDPipe) tenantId: string,
+  ): Promise<VisitorStatsResponseDto> {
+    this.logger.log(
+      `Obteniendo estadísticas de visitantes para tenant ${tenantId}`,
+    );
+
+    const query = GetVisitorStatsQuery.create({ tenantId });
     return await this.queryBus.execute(query);
   }
 

--- a/src/context/visitors-v2/infrastructure/controllers/visitor-v2.controller.ts
+++ b/src/context/visitors-v2/infrastructure/controllers/visitor-v2.controller.ts
@@ -171,7 +171,16 @@ export class VisitorV2Controller {
 
       return result;
     } catch (error) {
-      this.logger.error('Error al identificar visitante:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorStack = error instanceof Error ? error.stack : undefined;
+
+      this.logger.error('Error al identificar visitante:', errorMessage);
+      this.logger.error('Stack trace:', errorStack);
+      this.logger.error(
+        'Error name:',
+        error instanceof Error ? error.name : 'Unknown',
+      );
 
       // Si es un error de validación o datos inválidos
       if (
@@ -182,9 +191,9 @@ export class VisitorV2Controller {
         throw new BadRequestException(error.message);
       }
 
-      // Error genérico del servidor
+      // Devolver el error real en desarrollo para debugging
       throw new InternalServerErrorException(
-        'Error interno al identificar visitante',
+        `Error interno al identificar visitante: ${errorMessage}`,
       );
     }
   }

--- a/src/context/visitors-v2/visitors-v2.module.ts
+++ b/src/context/visitors-v2/visitors-v2.module.ts
@@ -48,6 +48,7 @@ import { GetVisitorSiteQueryHandler } from './application/queries/get-visitor-si
 import { SearchVisitorsQueryHandler } from './application/queries/search-visitors.query-handler';
 import { GetQuickFiltersConfigQueryHandler } from './application/queries/get-quick-filters-config.query-handler';
 import { GetSavedFiltersQueryHandler } from './application/queries/get-saved-filters.query-handler';
+import { GetVisitorStatsQueryHandler } from './application/queries/get-visitor-stats.query-handler';
 import { SaveFilterCommandHandler } from './application/commands/save-filter.command-handler';
 import { DeleteSavedFilterCommandHandler } from './application/commands/delete-saved-filter.command-handler';
 import { SavedFilterMongoRepositoryImpl } from './infrastructure/persistence/impl/saved-filter-mongo.repository.impl';
@@ -132,6 +133,7 @@ import { LeadScoringModule } from '../lead-scoring/lead-scoring.module';
     SearchVisitorsQueryHandler,
     GetQuickFiltersConfigQueryHandler,
     GetSavedFiltersQueryHandler,
+    GetVisitorStatsQueryHandler,
     SaveFilterCommandHandler,
     DeleteSavedFilterCommandHandler,
     SyncConnectionOnVisitorConnectionChangedEventHandler,

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import RedisStore from 'connect-redis';
 import { createClient, type RedisClientType } from 'redis';
 import * as fs from 'fs';
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
+import * as bodyParser from 'body-parser';
 
 // Tipo reducido para evitar callbacks (que introducen any en tipos externos) y pasar lint estricto.
 interface SafeCorsOptions {
@@ -130,6 +131,14 @@ async function bootstrap() {
         sameSite: sessionSameSite,
         maxAge: 15 * 60 * 1000,
       },
+    }),
+  );
+
+  // Aumentar límite del body parser para requests grandes (Tracking V2 events, etc.)
+  app.use(
+    bodyParser.json({
+      limit: '10mb',
+      strict: false,
     }),
   );
 

--- a/tools/cli.ts
+++ b/tools/cli.ts
@@ -47,6 +47,7 @@ import {
   ApiKeyRepository,
 } from '../src/context/auth/api-key/domain/repository/api-key.repository';
 import { ApiKeyCompanyId } from '../src/context/auth/api-key/domain/model/api-key-company-id';
+import { CreateApiKeyForDomainUseCase } from '../src/context/auth/api-key/application/usecase/create-api-key-for-domain.usecase';
 import {
   USER_ACCOUNT_REPOSITORY,
   UserAccountRepository,
@@ -59,6 +60,7 @@ import { UserAccountPassword } from '../src/context/auth/auth-user/domain/user-a
 import { UserAccountRoles } from '../src/context/auth/auth-user/domain/value-objects/user-account-roles';
 import { Role } from '../src/context/auth/auth-user/domain/value-objects/role';
 import { UserAccountCompanyId } from '../src/context/auth/auth-user/domain/value-objects/user-account-company-id';
+import { UserAccountKeycloakId } from '../src/context/auth/auth-user/domain/value-objects/user-account-keycloak-id';
 import {
   USER_PASSWORD_HASHER,
   UserPasswordHasher,
@@ -833,6 +835,122 @@ program
       }
     },
   );
+
+program
+  .command('create-apikey')
+  .description('Crea una API key para un dominio específico')
+  .requiredOption('--domain <domain>', 'Dominio para la API key')
+  .requiredOption('--company-id <companyId>', 'ID de la compañía')
+  .action(async (options: Record<string, string>) => {
+    const logger = new Logger('CreateApiKey');
+    const app = await NestFactory.createApplicationContext(AppModule);
+    const createApiKeyUseCase = app.get(CreateApiKeyForDomainUseCase);
+    const { ApiKeyDomain } = await import('../src/context/auth/api-key/domain/model/api-key-domain');
+    const { ApiKeyCompanyId } = await import('../src/context/auth/api-key/domain/model/api-key-company-id');
+
+    const domain = options.domain;
+    const companyId = options.companyId;
+
+    try {
+      const result = await createApiKeyUseCase.execute(
+        ApiKeyDomain.create(domain),
+        ApiKeyCompanyId.create(companyId),
+      );
+      logger.log(`API Key creada exitosamente`);
+      logger.log(`  Dominio: ${domain}`);
+      logger.log(`  API Key: ${result.apiKey}`);
+    } catch (error) {
+      logger.error(`Error creando API Key: ${error}`);
+    }
+
+    await app.close();
+  });
+
+program
+  .command('get-apikeys')
+  .description('Obtiene las API keys de una company')
+  .requiredOption('--company-id <companyId>', 'ID de la compañía')
+  .action(async (options: Record<string, string>) => {
+    const logger = new Logger('GetApiKeys');
+    const app = await NestFactory.createApplicationContext(AppModule);
+    const apiKeyRepository = app.get<ApiKeyRepository>(API_KEY_REPOSITORY);
+
+    const companyId = options.companyId;
+    const apiKeys = await apiKeyRepository.getApiKeysByCompanyId(ApiKeyCompanyId.create(companyId));
+
+    if (apiKeys.length === 0) {
+      logger.warn('No se encontraron API keys para esta company');
+    } else {
+      logger.log(`API Keys encontradas: ${apiKeys.length}`);
+      apiKeys.forEach((k, i) => {
+        console.log(`\nAPI Key ${i + 1}:`);
+        console.log(`  Dominio: ${k.domain.getValue()}`);
+        console.log(`  API Key: ${k.apiKey.getValue()}`);
+      });
+      console.log('');
+    }
+
+    await app.close();
+  });
+
+program
+  .command('create-user-from-keycloak')
+  .description('Crea o actualiza un usuario en BD vinculado a Keycloak')
+  .requiredOption('--keycloak-id <keycloakId>', 'ID del usuario en Keycloak')
+  .requiredOption('--email <email>', 'Email del usuario')
+  .requiredOption('--name <name>', 'Nombre del usuario')
+  .requiredOption('--company-id <companyId>', 'ID de la compañía')
+  .option('--role <role>', 'Rol del usuario', 'admin')
+  .action(async (options: Record<string, string>) => {
+    const logger = new Logger('CreateUserFromKeycloak');
+    const app = await NestFactory.createApplicationContext(AppModule);
+    const userRepository = app.get<UserAccountRepository>(USER_ACCOUNT_REPOSITORY);
+    const hasher = app.get<UserPasswordHasher>(USER_PASSWORD_HASHER);
+    const publisher = app.get(EventPublisher);
+
+    const keycloakId = options.keycloakId;
+    const email = options.email;
+    const name = options.name;
+    const companyId = options.companyId;
+    const roleValue = options.role?.toUpperCase() || 'ADMIN';
+    const role = roleValue === 'ADMIN' ? Role.admin() : roleValue === 'SUPERADMIN' ? Role.superadmin() : roleValue === 'COMMERCIAL' ? Role.commercial() : roleValue === 'SUPERVISOR' ? Role.supervisor() : Role.admin();
+
+    const existing = await userRepository.findByEmail(email);
+    if (existing) {
+      const existingPrimitives = existing.toPrimitives();
+      logger.log(`Usuario ya existe: ${existingPrimitives.id} — actualizando vínculo Keycloak`);
+      if (!existingPrimitives.keycloakId) {
+        const linked = existing.linkWithKeycloak(UserAccountKeycloakId.fromString(keycloakId));
+        const ctx = publisher.mergeObjectContext(linked);
+        await userRepository.save(ctx);
+        ctx.commit();
+        logger.log(`✅ Vinculado Keycloak ID: ${keycloakId}`);
+      } else {
+        logger.log(`Ya tiene Keycloak ID: ${existingPrimitives.keycloakId}`);
+      }
+    } else {
+      logger.log(`Creando usuario: ${email}`);
+      const hashedPassword = await hasher.hash('SSO_NO_REQUIRES_PASSWORD');
+      const user = UserAccount.create({
+        id: UserAccountId.create(Uuid.random().value),
+        email: UserAccountEmail.create(email),
+        name: new UserAccountName(name),
+        password: new UserAccountPassword(hashedPassword),
+        roles: UserAccountRoles.create([role]),
+        companyId: UserAccountCompanyId.create(companyId),
+      });
+      const linked = user.linkWithKeycloak(UserAccountKeycloakId.fromString(keycloakId));
+      const context = publisher.mergeObjectContext(linked);
+      await userRepository.save(context);
+      context.commit();
+      const createdPrimitives = linked.toPrimitives();
+      logger.log(`✅ Usuario creado: ${createdPrimitives.id}`);
+      logger.log(`   Keycloak ID: ${keycloakId}`);
+      logger.log(`   Company ID: ${companyId}`);
+    }
+
+    await app.close();
+  });
 
 program
   .parseAsync(process.argv)


### PR DESCRIPTION
## Resumen

Corrección para que las notificaciones WebSocket funcionen tanto en el inbox como en la lista de visitantes, actualizando los badges de notificaciones en tiempo real.

## Cambios

### Notificaciones WebSocket (Core fix)
- **UnreadCountUpdatedEvent** ahora incluye  y 
- **NotifyUnreadCountUpdatedOnUnreadCountUpdatedEventHandler** ahora emite también al room `tenant:{companyId}`
- **NotifyChatCreatedOnChatCreatedEventHandler** ahora emite también al room `tenant:{companyId}`
- Actualizados publishers en  y 

### Dominio con puerto
- **CanonicalDomain** acepta formato `localhost:puerto` para desarrollo local

### CLI Commands (herramientas)
- `create-user-from-keycloak`: vincula usuarios de BD con Keycloak
- `create-apikey`: crea API keys manualmente  
- `get-apikeys`: obtiene API keys de una company

### Fix de linter
- `main.ts`: reemplazado `require('body-parser')` por `import` ES6

## Comportamiento esperado

El frontend que escucha en el room `tenant:{companyId}` ahora recibe:
- `chat:unread_count` - para actualizar badges de visitantes con mensajes no leídos
- `chat:created` - para actualizar la lista cuando se crea un nuevo chat

## Tests

- 478 tests passing, 0 failures
- Test de  actualizado para esperar 2 emisiones (visitor + tenant)

## Archivos modificados

```
src/context/conversations-v2/application/events/notify-chat-created-on-chat-created.event-handler.ts
src/context/conversations-v2/application/events/notify-unread-count-updated-on-unread-count-updated.event-handler.ts
src/context/conversations-v2/application/events/update-chat-on-message-sent.event-handler.ts
src/context/conversations-v2/application/commands/reset-chat-unread-count.command-handler.ts
src/context/conversations-v2/domain/events/unread-count-updated.event.ts
src/context/company/domain/value-objects/canonical-domain.ts
src/main.ts
tools/cli.ts
```